### PR TITLE
feat: add --input-dir/--recursive batch split support to AudioSplitter.Cli

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@
 以下は課題解決を行うための一通りの遂行手順である
 
 1. Userから受けた指示を詳細に記述し，認識齟齬がないかをUserに確認する
-2. リポジトリ直下の主要ファイル（`AGENTS.md` / `AudioProcessor.slnx` / `AudioSplitter.Cli/AudioSplitter.Cli.csproj` / `.gitignore`）と実装ファイルを確認し，構成と記述方針を把握する
+2. リポジトリ直下の主要ファイル（`AGENTS.md` / `AudioProcessor.slnx` / `AudioProcessor/AudioProcessor.csproj` / `.gitignore`）と実装ファイルを確認し，構成と記述方針を把握する
 3. 無変更時，ビルドがPassすることを確認する
   - プロジェクトルートで`dotnet build`を実行し，`AudioProcessor.slnx`を通してビルドが完遂するか確認する
 4. Userに可能な限り詳細に仕様を確認し，実装可能なレベルまで構成をFixさせる
@@ -38,8 +38,13 @@
   - 同一層の実装や類似の実装が存在しないか，プロジェクト全体を一度落ち着いて詳細に確認して統一性が保たれているか確認する
   - プロジェクトルートで`dotnet build`を実行し，`AudioProcessor.slnx`を通してビルドが完遂するか確認する
     - **Warningも解消する必要がある**． Warningを解消する際もビルド結果と実装範囲全体の確認を怠らないこと
-      - つまり，`.editorconfig` `AudioSplitter.Cli/AudioSplitter.Cli.csproj` 及びビルド結果の詳細を合わせて確認する必要がある
-6. 実装ファイルをコミットする
+      - つまり，`.editorconfig` `AudioProcessor/AudioProcessor.csproj` 及びビルド結果の詳細を合わせて確認する必要がある
+6. ドキュメントの更新を行う
+  - 着手したプロジェクト、ソリューション全体のREADMEは高確率で変更となる
+  - サードパーティライブラリを追加した場合、ライセンス関連の記述は確実に変更となる
+  - テストプロジェクト以外の全プロジェクトにREADMEが必要
+7. 実装ファイルをコミットし、PRを作成する
+  - PR承認/マージ時、該当issueをCloseするように定義すること
 
 ### 本プロジェクト固有の実装パターン
 本プロジェクトでは，以下の要件をマストで満たす必要がある
@@ -49,14 +54,12 @@
 
 - `AudioProcessor.slnx`
   - ソリューション定義．原則このファイルをターゲットとしてビルド確認を行う
-- `AudioSplitter.Cli/AudioSplitter.Cli.csproj`
-  - コンソールアプリのビルド設定（`OutputType`, `TargetFramework` 等）
 - 実装コード（`*.cs`）
   - ツール本体ロジック
 - `.gitignore`
   - ローカル生成物やIDE生成物の除外設定
 
-上記以外に新規のプロジェクトをソリューションに含めてはならない
+上記以外のソリューションをリポジトリに含めてはならない
 適切な名前空間に適切な定義を配置し，一貫性のある整ったコーディングを心がけること
 これらは常に意識する必要がある
 
@@ -76,7 +79,7 @@
 
 - `dotnet build AudioProcessor.slnx -warnaserror` の実行結果をテキストで保存し，`build-logs/` 配下に `yyyy-MM-ddTHHmmss-*.txt` 形式で管理する
 - 必要に応じて過去に出力したビルドログを確認すること
-- Analyzer/警告対応のレビューでは `.editorconfig`（存在する場合）と `AudioSplitter.Cli/AudioSplitter.Cli.csproj` も合わせて添付する
+- Analyzer/警告対応のレビューでは `.editorconfig`（存在する場合）と `AudioProcessor/AudioProcessor.csproj` も合わせて添付する
 - 目的は「ビルド状態の再現性・可観測性」の確保であり，履歴が残らないChatToolにおいても都度ログを共有することで齟齬を無くす
 
 ##### 作業着手時の最小確認ファイル
@@ -85,7 +88,13 @@
 - docs/**
   - **必ず**すべてを熟読すること
 - AudioProcessor.slnx
-- AudioSplitter.Cli/AudioSplitter.Cli.csproj
+- AudioProcessor/AudioProcessor.csproj
+- README.md
+- CODE_OF_CONDUCT.md
+- CONTRIBUTING.md
+- SUPPORT.md
+- THIRD_PARTY_NOTICES.md
 - .gitignore
 - 実装対象の `*.cs` ファイル
+- 実装対象プロジェクトの `README.md` ファイル
 - 前回ビルドの出力ログ（直近ビルド結果を連携する必要がある場合テキストで連携）

--- a/AudioProcessor.slnx
+++ b/AudioProcessor.slnx
@@ -2,6 +2,7 @@
   <Project Path="AudioProcessor.Tests/AudioProcessor.Tests.csproj" />
   <Project Path="AudioProcessor/AudioProcessor.csproj" />
   <Project Path="AudioSplitter.Cli/AudioSplitter.Cli.csproj" />
+  <Project Path="AudioSplitter.Cli.Tests/AudioSplitter.Cli.Tests.csproj" />
   <Project Path="AudioSplitter.Core.Tests/AudioSplitter.Core.Tests.csproj" />
   <Project Path="AudioSplitter.Core/AudioSplitter.Core.csproj" />
   <Project Path="PeakAnalyzer.Core.Tests/PeakAnalyzer.Core.Tests.csproj" />

--- a/AudioSplitter.Cli.Tests/AudioSplitter.Cli.Tests.csproj
+++ b/AudioSplitter.Cli.Tests/AudioSplitter.Cli.Tests.csproj
@@ -1,27 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" />
-    <PackageReference Include="NAudio" />
-    <PackageReference Include="OpenTK.Audio.OpenAL" VersionOverride="4.9.4" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AudioSplitter.Cli\AudioSplitter.Cli.csproj" />
     <ProjectReference Include="..\AudioSplitter.Core\AudioSplitter.Core.csproj" />
+    <ProjectReference Include="..\AudioProcessor\AudioProcessor.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="Middleware\**\*.cs" />
     <Compile Include="Infrastructure\**\*.cs" />
     <Compile Include="Presentation\**\*.cs" />
   </ItemGroup>

--- a/AudioSplitter.Cli.Tests/Infrastructure/Execution/SplitAudioBatchExecutorTests.cs
+++ b/AudioSplitter.Cli.Tests/Infrastructure/Execution/SplitAudioBatchExecutorTests.cs
@@ -1,0 +1,307 @@
+using AudioProcessor.Application.Errors;
+using AudioProcessor.Application.Models;
+using AudioProcessor.Application.Ports;
+using AudioProcessor.Domain.Models;
+using AudioSplitter.Cli.Infrastructure.Execution;
+using AudioSplitter.Cli.Presentation.Cli.Arguments;
+using AudioSplitter.Core.Application.Models;
+using AudioSplitter.Core.Application.Ports;
+using AudioSplitter.Core.Application.UseCases;
+using AudioSplitter.Core.Domain.Models;
+using AudioSplitter.Core.Domain.ValueObjects;
+
+namespace AudioSplitter.Cli.Tests.Infrastructure.Execution;
+
+public sealed class SplitAudioBatchExecutorTests
+{
+    [Fact]
+    public async Task ExecuteAsync_ShouldAggregateSummary_WhenInputFileIsSpecified()
+    {
+        string inputPath = await CreateTempInputFileAsync("single-input.wav");
+        string outputDirectoryPath = CreateTempDirectory();
+        try
+        {
+            FakeSegmentExporter exporter = new();
+            SplitAudioBatchExecutor executor = BuildExecutor(exporter);
+            CommandLineArguments arguments = CreateInputFileArguments(inputPath, outputDirectoryPath);
+
+            SplitAudioBatchSummary summary = await executor.ExecuteAsync(arguments, CancellationToken.None);
+
+            Assert.Equal(1, summary.ProcessedFileCount);
+            Assert.Equal(1, summary.GeneratedCount);
+            Assert.Equal(0, summary.SkippedCount);
+            Assert.Equal(0, summary.PromptedCount);
+            Assert.Equal(1, summary.DetectedSegmentCount);
+            Assert.Single(exporter.Requests);
+            string expected = Path.Combine(outputDirectoryPath, "single-input_001.wav");
+            Assert.Equal(expected, exporter.Requests[0].OutputFilePath, ignoreCase: true);
+        }
+        finally
+        {
+            File.Delete(inputPath);
+            string? inputDirectoryPath = Path.GetDirectoryName(inputPath);
+            if (!string.IsNullOrWhiteSpace(inputDirectoryPath) && Directory.Exists(inputDirectoryPath))
+            {
+                Directory.Delete(inputDirectoryPath, recursive: true);
+            }
+
+            Directory.Delete(outputDirectoryPath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldPreserveRelativeDirectory_WhenInputDirIsSpecified()
+    {
+        string inputRootPath = CreateTempDirectory();
+        string outputRootPath = CreateTempDirectory();
+        try
+        {
+            string subDirectoryPath = Path.Combine(inputRootPath, "Sub");
+            Directory.CreateDirectory(subDirectoryPath);
+            string inputPath = Path.Combine(subDirectoryPath, "file.wav");
+            await File.WriteAllTextAsync(inputPath, "content");
+
+            FakeSegmentExporter exporter = new();
+            SplitAudioBatchExecutor executor = BuildExecutor(exporter);
+            CommandLineArguments arguments = CreateInputDirectoryArguments(inputRootPath, outputRootPath, recursive: true);
+
+            SplitAudioBatchSummary summary = await executor.ExecuteAsync(arguments, CancellationToken.None);
+
+            Assert.Equal(1, summary.ProcessedFileCount);
+            Assert.Equal(1, summary.GeneratedCount);
+            Assert.Single(exporter.Requests);
+            string expectedDirectoryPath = Path.Combine(outputRootPath, "Sub");
+            string actualDirectoryPath = Path.GetDirectoryName(exporter.Requests[0].OutputFilePath) ?? string.Empty;
+            Assert.Equal(expectedDirectoryPath, actualDirectoryPath, ignoreCase: true);
+            Assert.Equal("file_001.wav", Path.GetFileName(exporter.Requests[0].OutputFilePath), StringComparer.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(inputRootPath, recursive: true);
+            Directory.Delete(outputRootPath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldReturnZeroSummary_WhenNoSupportedFileExists()
+    {
+        string inputRootPath = CreateTempDirectory();
+        string outputRootPath = CreateTempDirectory();
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(inputRootPath, "note.txt"), "text");
+
+            FakeSegmentExporter exporter = new();
+            SplitAudioBatchExecutor executor = BuildExecutor(exporter);
+            CommandLineArguments arguments = CreateInputDirectoryArguments(inputRootPath, outputRootPath, recursive: true);
+
+            SplitAudioBatchSummary summary = await executor.ExecuteAsync(arguments, CancellationToken.None);
+
+            Assert.Equal(0, summary.ProcessedFileCount);
+            Assert.Equal(0, summary.GeneratedCount);
+            Assert.Equal(0, summary.SkippedCount);
+            Assert.Equal(0, summary.PromptedCount);
+            Assert.Equal(0, summary.DetectedSegmentCount);
+            Assert.Empty(exporter.Requests);
+        }
+        finally
+        {
+            Directory.Delete(inputRootPath, recursive: true);
+            Directory.Delete(outputRootPath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldFailFast_WhenExportFails()
+    {
+        string inputRootPath = CreateTempDirectory();
+        string outputRootPath = CreateTempDirectory();
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(inputRootPath, "a.wav"), "a");
+            await File.WriteAllTextAsync(Path.Combine(inputRootPath, "b.wav"), "b");
+
+            FakeSegmentExporter exporter = new(failAtRequestNumber: 1);
+            SplitAudioBatchExecutor executor = BuildExecutor(exporter);
+            CommandLineArguments arguments = CreateInputDirectoryArguments(inputRootPath, outputRootPath, recursive: false);
+
+            await Assert.ThrowsAsync<AudioProcessorException>(
+                () => executor.ExecuteAsync(arguments, CancellationToken.None));
+            Assert.Single(exporter.Requests);
+        }
+        finally
+        {
+            Directory.Delete(inputRootPath, recursive: true);
+            Directory.Delete(outputRootPath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldThrowCliException_WhenInputDirectoryDoesNotExist()
+    {
+        string outputRootPath = CreateTempDirectory();
+        try
+        {
+            string missingInputDirectoryPath = Path.Combine(outputRootPath, "missing-input");
+            FakeSegmentExporter exporter = new();
+            SplitAudioBatchExecutor executor = BuildExecutor(exporter);
+            CommandLineArguments arguments = CreateInputDirectoryArguments(
+                missingInputDirectoryPath,
+                outputRootPath,
+                recursive: false);
+
+            CliException exception = await Assert.ThrowsAsync<CliException>(
+                () => executor.ExecuteAsync(arguments, CancellationToken.None));
+            Assert.Equal(CliErrorCode.InputDirectoryNotFound, exception.ErrorCode);
+        }
+        finally
+        {
+            Directory.Delete(outputRootPath, recursive: true);
+        }
+    }
+
+    private static SplitAudioBatchExecutor BuildExecutor(FakeSegmentExporter exporter)
+    {
+        ArgumentNullException.ThrowIfNull(exporter);
+
+        SplitAudioUseCase useCase = new(
+            new FakeFfmpegLocator(),
+            new FakeProbeService(new AudioStreamInfo(44_100, 2, AudioPcmBitDepth.Pcm24, 1_000)),
+            new FakeSilenceAnalyzer(new SilenceAnalysisResult(1_000, 0, Array.Empty<SilenceRun>())),
+            exporter,
+            new AlwaysOverwriteService());
+        return new SplitAudioBatchExecutor(useCase);
+    }
+
+    private static CommandLineArguments CreateInputFileArguments(string inputFilePath, string outputDirectoryPath)
+    {
+        return new CommandLineArguments(
+            inputFilePath,
+            inputDirectoryPath: null,
+            outputDirectoryPath,
+            levelDb: -48.0,
+            duration: TimeSpan.FromMilliseconds(2_000),
+            afterOffset: TimeSpan.Zero,
+            resumeOffset: TimeSpan.Zero,
+            resolutionType: null,
+            ffmpegPath: null,
+            overwriteWithoutPrompt: true,
+            recursive: false);
+    }
+
+    private static CommandLineArguments CreateInputDirectoryArguments(
+        string inputDirectoryPath,
+        string outputDirectoryPath,
+        bool recursive)
+    {
+        return new CommandLineArguments(
+            inputFilePath: null,
+            inputDirectoryPath,
+            outputDirectoryPath,
+            levelDb: -48.0,
+            duration: TimeSpan.FromMilliseconds(2_000),
+            afterOffset: TimeSpan.Zero,
+            resumeOffset: TimeSpan.Zero,
+            resolutionType: null,
+            ffmpegPath: null,
+            overwriteWithoutPrompt: true,
+            recursive);
+    }
+
+    private static string CreateTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"audio-splitter-batch-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static async Task<string> CreateTempInputFileAsync(string fileName)
+    {
+        string directoryPath = CreateTempDirectory();
+        string filePath = Path.Combine(directoryPath, fileName);
+        await File.WriteAllTextAsync(filePath, "input").ConfigureAwait(false);
+        return filePath;
+    }
+
+    private sealed class FakeFfmpegLocator : IFfmpegLocator
+    {
+        public FfmpegToolPaths Resolve(string? ffmpegPath)
+        {
+            return new FfmpegToolPaths("ffmpeg", "ffprobe");
+        }
+    }
+
+    private sealed class FakeProbeService : IAudioProbeService
+    {
+        private readonly AudioStreamInfo streamInfo;
+
+        public FakeProbeService(AudioStreamInfo streamInfo)
+        {
+            this.streamInfo = streamInfo ?? throw new ArgumentNullException(nameof(streamInfo));
+        }
+
+        public Task<AudioStreamInfo> ProbeAsync(
+            FfmpegToolPaths toolPaths,
+            string inputFilePath,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(streamInfo);
+        }
+    }
+
+    private sealed class FakeSilenceAnalyzer : ISilenceAnalyzer
+    {
+        private readonly SilenceAnalysisResult analysisResult;
+
+        public FakeSilenceAnalyzer(SilenceAnalysisResult analysisResult)
+        {
+            this.analysisResult = analysisResult ?? throw new ArgumentNullException(nameof(analysisResult));
+        }
+
+        public Task<SilenceAnalysisResult> AnalyzeAsync(
+            FfmpegToolPaths toolPaths,
+            string inputFilePath,
+            AudioStreamInfo streamInfo,
+            double levelDb,
+            TimeSpan duration,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(analysisResult);
+        }
+    }
+
+    private sealed class FakeSegmentExporter : IAudioSegmentExporter
+    {
+        private readonly int failAtRequestNumber;
+
+        public FakeSegmentExporter(int failAtRequestNumber = 0)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(failAtRequestNumber);
+            this.failAtRequestNumber = failAtRequestNumber;
+        }
+
+        public List<SegmentExportRequest> Requests { get; } = new();
+
+        public Task ExportAsync(
+            FfmpegToolPaths toolPaths,
+            SegmentExportRequest request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            if (failAtRequestNumber > 0 && Requests.Count == failAtRequestNumber)
+            {
+                throw new AudioProcessorException(AudioProcessorErrorCode.ExportFailed, "Simulated export failure");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class AlwaysOverwriteService : IOverwriteConfirmationService
+    {
+        public OverwriteDecision Resolve(string outputPath, bool overwriteWithoutPrompt)
+        {
+            return new OverwriteDecision(true, false);
+        }
+    }
+}

--- a/AudioSplitter.Cli.Tests/Infrastructure/FileSystem/InputAudioFileResolverTests.cs
+++ b/AudioSplitter.Cli.Tests/Infrastructure/FileSystem/InputAudioFileResolverTests.cs
@@ -1,0 +1,116 @@
+using AudioSplitter.Cli.Infrastructure.FileSystem;
+
+namespace AudioSplitter.Cli.Tests.Infrastructure.FileSystem;
+
+public sealed class InputAudioFileResolverTests
+{
+    [Fact]
+    public void Resolve_ShouldScanTopDirectoryOnly_WhenRecursiveIsFalse()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            string topLevel = Path.Combine(root, "Top.wav");
+            File.WriteAllText(topLevel, "top");
+
+            string subDir = Path.Combine(root, "Sub");
+            Directory.CreateDirectory(subDir);
+            File.WriteAllText(Path.Combine(subDir, "Nested.wav"), "nested");
+
+            IReadOnlyList<ResolvedInputAudioFile> resolved = InputAudioFileResolver.Resolve(root, recursive: false);
+
+            Assert.Single(resolved);
+            Assert.Equal(topLevel, resolved[0].InputFilePath, ignoreCase: true);
+            Assert.Equal(string.Empty, resolved[0].RelativeDirectoryPath, StringComparer.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Resolve_ShouldIncludeNestedFiles_WhenRecursiveIsTrue()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            string topLevel = Path.Combine(root, "Top.flac");
+            File.WriteAllText(topLevel, "top");
+
+            string subDir = Path.Combine(root, "Sub");
+            Directory.CreateDirectory(subDir);
+            string nested = Path.Combine(subDir, "Nested.wav");
+            File.WriteAllText(nested, "nested");
+
+            IReadOnlyList<ResolvedInputAudioFile> resolved = InputAudioFileResolver.Resolve(root, recursive: true);
+
+            Assert.Equal(2, resolved.Count);
+            Assert.Contains(
+                resolved,
+                item => string.Equals(item.InputFilePath, topLevel, StringComparison.OrdinalIgnoreCase)
+                    && item.RelativeDirectoryPath.Length == 0);
+            Assert.Contains(
+                resolved,
+                item => string.Equals(item.InputFilePath, nested, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(item.RelativeDirectoryPath, "Sub", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Resolve_ShouldFilterUnsupportedExtensions()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "A.wav"), "wav");
+            File.WriteAllText(Path.Combine(root, "B.CAF"), "caf");
+            File.WriteAllText(Path.Combine(root, "C.txt"), "txt");
+
+            IReadOnlyList<ResolvedInputAudioFile> resolved = InputAudioFileResolver.Resolve(root, recursive: true);
+
+            Assert.Equal(2, resolved.Count);
+            Assert.DoesNotContain(
+                resolved,
+                item => string.Equals(Path.GetExtension(item.InputFilePath), ".txt", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Resolve_ShouldSortByPathCaseInsensitive()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            string lower = Path.Combine(root, "a.wav");
+            string upper = Path.Combine(root, "B.wav");
+            File.WriteAllText(upper, "b");
+            File.WriteAllText(lower, "a");
+
+            IReadOnlyList<ResolvedInputAudioFile> resolved = InputAudioFileResolver.Resolve(root, recursive: false);
+
+            Assert.Equal(2, resolved.Count);
+            Assert.Equal(lower, resolved[0].InputFilePath, ignoreCase: true);
+            Assert.Equal(upper, resolved[1].InputFilePath, ignoreCase: true);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static string CreateTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"audio-splitter-cli-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/AudioSplitter.Cli.Tests/Presentation/Cli/Arguments/CommandLineParserTests.cs
+++ b/AudioSplitter.Cli.Tests/Presentation/Cli/Arguments/CommandLineParserTests.cs
@@ -1,0 +1,94 @@
+using AudioSplitter.Cli.Presentation.Cli.Arguments;
+using AudioSplitter.Cli.Presentation.Cli.Texts;
+
+namespace AudioSplitter.Cli.Tests.Presentation.Cli.Arguments;
+
+public sealed class CommandLineParserTests
+{
+    private static readonly string[] BaseArgs =
+    [
+        "--output-dir", "C:/out",
+        "--level", "-48.0",
+        "--duration", "2000ms",
+    ];
+
+    [Fact]
+    public void Parse_ShouldSucceed_WhenInputFileIsSpecified()
+    {
+        string[] args =
+        [
+            .. BaseArgs,
+            "--input-file", "C:/input/file.wav",
+        ];
+
+        CommandLineParseResult result = CommandLineParser.Parse(args);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Arguments);
+        Assert.Equal("C:/input/file.wav", result.Arguments.InputFilePath, StringComparer.Ordinal);
+        Assert.Null(result.Arguments.InputDirectoryPath);
+        Assert.False(result.Arguments.Recursive);
+    }
+
+    [Fact]
+    public void Parse_ShouldSucceed_WhenInputDirAndRecursiveAreSpecified()
+    {
+        string[] args =
+        [
+            .. BaseArgs,
+            "--input-dir", "C:/input",
+            "--recursive",
+        ];
+
+        CommandLineParseResult result = CommandLineParser.Parse(args);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Arguments);
+        Assert.Null(result.Arguments.InputFilePath);
+        Assert.Equal("C:/input", result.Arguments.InputDirectoryPath, StringComparer.Ordinal);
+        Assert.True(result.Arguments.Recursive);
+    }
+
+    [Fact]
+    public void Parse_ShouldFail_WhenInputFileAndInputDirAreSpecifiedTogether()
+    {
+        string[] args =
+        [
+            .. BaseArgs,
+            "--input-file", "C:/input/file.wav",
+            "--input-dir", "C:/input",
+        ];
+
+        CommandLineParseResult result = CommandLineParser.Parse(args);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(ConsoleTexts.InputSourceExclusiveText, result.Errors, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_ShouldFail_WhenInputSourceIsNotSpecified()
+    {
+        string[] args = [.. BaseArgs];
+
+        CommandLineParseResult result = CommandLineParser.Parse(args);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(ConsoleTexts.InputSourceRequiredText, result.Errors, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_ShouldFail_WhenRecursiveIsSpecifiedWithoutInputDir()
+    {
+        string[] args =
+        [
+            .. BaseArgs,
+            "--input-file", "C:/input/file.wav",
+            "--recursive",
+        ];
+
+        CommandLineParseResult result = CommandLineParser.Parse(args);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(ConsoleTexts.RecursiveRequiresInputDirText, result.Errors, StringComparer.Ordinal);
+    }
+}

--- a/AudioSplitter.Cli/Infrastructure/Execution/CliErrorCode.cs
+++ b/AudioSplitter.Cli/Infrastructure/Execution/CliErrorCode.cs
@@ -1,0 +1,7 @@
+namespace AudioSplitter.Cli.Infrastructure.Execution;
+
+internal enum CliErrorCode
+{
+    None = 0,
+    InputDirectoryNotFound,
+}

--- a/AudioSplitter.Cli/Infrastructure/Execution/CliException.cs
+++ b/AudioSplitter.Cli/Infrastructure/Execution/CliException.cs
@@ -1,0 +1,39 @@
+namespace AudioSplitter.Cli.Infrastructure.Execution;
+
+#pragma warning disable S3871
+internal sealed class CliException : Exception
+{
+    public CliException()
+        : this(CliErrorCode.None, string.Empty)
+    {
+    }
+
+    public CliException(string message)
+        : this(CliErrorCode.None, message)
+    {
+    }
+
+    public CliException(string message, Exception innerException)
+        : this(CliErrorCode.None, message, innerException)
+    {
+    }
+
+    public CliException(CliErrorCode errorCode, string detail)
+        : base(detail)
+    {
+        ErrorCode = errorCode;
+        Detail = detail;
+    }
+
+    public CliException(CliErrorCode errorCode, string detail, Exception innerException)
+        : base(detail, innerException)
+    {
+        ErrorCode = errorCode;
+        Detail = detail;
+    }
+
+    public CliErrorCode ErrorCode { get; }
+
+    public string Detail { get; }
+}
+#pragma warning restore S3871

--- a/AudioSplitter.Cli/Infrastructure/Execution/SplitAudioBatchExecutor.cs
+++ b/AudioSplitter.Cli/Infrastructure/Execution/SplitAudioBatchExecutor.cs
@@ -1,0 +1,100 @@
+using AudioSplitter.Cli.Infrastructure.FileSystem;
+using AudioSplitter.Cli.Presentation.Cli.Arguments;
+using AudioSplitter.Core.Application.Models;
+using AudioSplitter.Core.Application.UseCases;
+
+namespace AudioSplitter.Cli.Infrastructure.Execution;
+
+internal sealed class SplitAudioBatchExecutor
+{
+    private readonly SplitAudioUseCase splitAudioUseCase;
+
+    public SplitAudioBatchExecutor(SplitAudioUseCase splitAudioUseCase)
+    {
+        this.splitAudioUseCase = splitAudioUseCase ?? throw new ArgumentNullException(nameof(splitAudioUseCase));
+    }
+
+    public async Task<SplitAudioBatchSummary> ExecuteAsync(
+        CommandLineArguments arguments,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        IReadOnlyList<ResolvedInputAudioFile> targets = ResolveTargets(arguments);
+        int processedFileCount = 0;
+        int generatedCount = 0;
+        int skippedCount = 0;
+        int promptedCount = 0;
+        int detectedSegmentCount = 0;
+
+        for (int i = 0; i < targets.Count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            ResolvedInputAudioFile target = targets[i];
+            string outputDirectoryPath = ResolveOutputDirectoryPath(
+                arguments.OutputDirectoryPath,
+                target.RelativeDirectoryPath);
+
+            SplitAudioRequest request = new(
+                target.InputFilePath,
+                outputDirectoryPath,
+                arguments.LevelDb,
+                arguments.Duration,
+                arguments.AfterOffset,
+                arguments.ResumeOffset,
+                arguments.ResolutionType,
+                arguments.FfmpegPath,
+                arguments.OverwriteWithoutPrompt);
+
+            SplitAudioExecutionResult result = await splitAudioUseCase
+                .ExecuteAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+
+            processedFileCount++;
+            generatedCount = checked(generatedCount + result.Summary.GeneratedCount);
+            skippedCount = checked(skippedCount + result.Summary.SkippedCount);
+            promptedCount = checked(promptedCount + result.Summary.PromptedCount);
+            detectedSegmentCount = checked(detectedSegmentCount + result.Summary.DetectedSegmentCount);
+        }
+
+        return new SplitAudioBatchSummary(
+            processedFileCount,
+            generatedCount,
+            skippedCount,
+            promptedCount,
+            detectedSegmentCount);
+    }
+
+    private static IReadOnlyList<ResolvedInputAudioFile> ResolveTargets(CommandLineArguments arguments)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        if (!string.IsNullOrWhiteSpace(arguments.InputFilePath))
+        {
+            return new[] { new ResolvedInputAudioFile(arguments.InputFilePath, string.Empty) };
+        }
+
+        string inputDirectoryPath = arguments.InputDirectoryPath
+            ?? throw new ArgumentException("InputDirectoryPath must be specified in directory mode.", nameof(arguments));
+        if (!Directory.Exists(inputDirectoryPath))
+        {
+            throw new CliException(CliErrorCode.InputDirectoryNotFound, inputDirectoryPath);
+        }
+
+        return InputAudioFileResolver.Resolve(inputDirectoryPath, arguments.Recursive);
+    }
+
+    private static string ResolveOutputDirectoryPath(string outputRootDirectoryPath, string relativeDirectoryPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputRootDirectoryPath);
+        ArgumentNullException.ThrowIfNull(relativeDirectoryPath);
+
+        if (string.IsNullOrWhiteSpace(relativeDirectoryPath))
+        {
+            return outputRootDirectoryPath;
+        }
+
+        return Path.Combine(outputRootDirectoryPath, relativeDirectoryPath);
+    }
+}

--- a/AudioSplitter.Cli/Infrastructure/Execution/SplitAudioBatchSummary.cs
+++ b/AudioSplitter.Cli/Infrastructure/Execution/SplitAudioBatchSummary.cs
@@ -1,0 +1,34 @@
+namespace AudioSplitter.Cli.Infrastructure.Execution;
+
+internal sealed class SplitAudioBatchSummary
+{
+    public SplitAudioBatchSummary(
+        int processedFileCount,
+        int generatedCount,
+        int skippedCount,
+        int promptedCount,
+        int detectedSegmentCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(processedFileCount);
+        ArgumentOutOfRangeException.ThrowIfNegative(generatedCount);
+        ArgumentOutOfRangeException.ThrowIfNegative(skippedCount);
+        ArgumentOutOfRangeException.ThrowIfNegative(promptedCount);
+        ArgumentOutOfRangeException.ThrowIfNegative(detectedSegmentCount);
+
+        ProcessedFileCount = processedFileCount;
+        GeneratedCount = generatedCount;
+        SkippedCount = skippedCount;
+        PromptedCount = promptedCount;
+        DetectedSegmentCount = detectedSegmentCount;
+    }
+
+    public int ProcessedFileCount { get; }
+
+    public int GeneratedCount { get; }
+
+    public int SkippedCount { get; }
+
+    public int PromptedCount { get; }
+
+    public int DetectedSegmentCount { get; }
+}

--- a/AudioSplitter.Cli/Infrastructure/FileSystem/InputAudioFileResolver.cs
+++ b/AudioSplitter.Cli/Infrastructure/FileSystem/InputAudioFileResolver.cs
@@ -1,0 +1,47 @@
+namespace AudioSplitter.Cli.Infrastructure.FileSystem;
+
+internal static class InputAudioFileResolver
+{
+    private static readonly HashSet<string> SupportedExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".wav",
+        ".flac",
+        ".m4a",
+        ".caf",
+    };
+
+    public static IReadOnlyList<ResolvedInputAudioFile> Resolve(string inputDirectoryPath, bool recursive)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(inputDirectoryPath);
+
+        SearchOption searchOption = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
+        string[] paths = Directory
+            .EnumerateFiles(inputDirectoryPath, "*", searchOption)
+            .Where(IsSupportedAudioFile)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        List<ResolvedInputAudioFile> resolved = new(paths.Length);
+        for (int i = 0; i < paths.Length; i++)
+        {
+            string inputFilePath = paths[i];
+            string parentDirectoryPath = Path.GetDirectoryName(inputFilePath) ?? inputDirectoryPath;
+            string relativeDirectoryPath = Path.GetRelativePath(inputDirectoryPath, parentDirectoryPath);
+            if (string.Equals(relativeDirectoryPath, ".", StringComparison.Ordinal))
+            {
+                relativeDirectoryPath = string.Empty;
+            }
+
+            resolved.Add(new ResolvedInputAudioFile(inputFilePath, relativeDirectoryPath));
+        }
+
+        return resolved;
+    }
+
+    private static bool IsSupportedAudioFile(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        string extension = Path.GetExtension(path);
+        return SupportedExtensions.Contains(extension);
+    }
+}

--- a/AudioSplitter.Cli/Infrastructure/FileSystem/ResolvedInputAudioFile.cs
+++ b/AudioSplitter.Cli/Infrastructure/FileSystem/ResolvedInputAudioFile.cs
@@ -1,0 +1,17 @@
+namespace AudioSplitter.Cli.Infrastructure.FileSystem;
+
+internal sealed class ResolvedInputAudioFile
+{
+    public ResolvedInputAudioFile(string inputFilePath, string relativeDirectoryPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(inputFilePath);
+        ArgumentNullException.ThrowIfNull(relativeDirectoryPath);
+
+        InputFilePath = inputFilePath;
+        RelativeDirectoryPath = relativeDirectoryPath;
+    }
+
+    public string InputFilePath { get; }
+
+    public string RelativeDirectoryPath { get; }
+}

--- a/AudioSplitter.Cli/Presentation/Cli/Arguments/CommandLineArguments.cs
+++ b/AudioSplitter.Cli/Presentation/Cli/Arguments/CommandLineArguments.cs
@@ -5,7 +5,8 @@ namespace AudioSplitter.Cli.Presentation.Cli.Arguments;
 internal sealed class CommandLineArguments
 {
     public CommandLineArguments(
-        string inputFilePath,
+        string? inputFilePath,
+        string? inputDirectoryPath,
         string outputDirectoryPath,
         double levelDb,
         TimeSpan duration,
@@ -13,12 +14,25 @@ internal sealed class CommandLineArguments
         TimeSpan resumeOffset,
         ResolutionType? resolutionType,
         string? ffmpegPath,
-        bool overwriteWithoutPrompt)
+        bool overwriteWithoutPrompt,
+        bool recursive)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(inputFilePath);
         ArgumentException.ThrowIfNullOrWhiteSpace(outputDirectoryPath);
 
-        InputFilePath = inputFilePath;
+        bool hasInputFile = !string.IsNullOrWhiteSpace(inputFilePath);
+        bool hasInputDirectory = !string.IsNullOrWhiteSpace(inputDirectoryPath);
+        if (hasInputFile == hasInputDirectory)
+        {
+            throw new ArgumentException("Exactly one of inputFilePath or inputDirectoryPath must be specified.");
+        }
+
+        if (recursive && !hasInputDirectory)
+        {
+            throw new ArgumentException("recursive requires inputDirectoryPath.");
+        }
+
+        InputFilePath = hasInputFile ? inputFilePath : null;
+        InputDirectoryPath = hasInputDirectory ? inputDirectoryPath : null;
         OutputDirectoryPath = outputDirectoryPath;
         LevelDb = levelDb;
         Duration = duration;
@@ -27,9 +41,12 @@ internal sealed class CommandLineArguments
         ResolutionType = resolutionType;
         FfmpegPath = ffmpegPath;
         OverwriteWithoutPrompt = overwriteWithoutPrompt;
+        Recursive = recursive;
     }
 
-    public string InputFilePath { get; }
+    public string? InputFilePath { get; }
+
+    public string? InputDirectoryPath { get; }
 
     public string OutputDirectoryPath { get; }
 
@@ -46,4 +63,6 @@ internal sealed class CommandLineArguments
     public string? FfmpegPath { get; }
 
     public bool OverwriteWithoutPrompt { get; }
+
+    public bool Recursive { get; }
 }

--- a/AudioSplitter.Cli/Presentation/Cli/Errors/CliErrorMapper.cs
+++ b/AudioSplitter.Cli/Presentation/Cli/Errors/CliErrorMapper.cs
@@ -1,4 +1,5 @@
 using AudioProcessor.Application.Errors;
+using AudioSplitter.Cli.Infrastructure.Execution;
 using AudioSplitter.Core.Application.Errors;
 using AudioSplitter.Cli.Presentation.Cli.Texts;
 
@@ -15,6 +16,17 @@ internal static class CliErrorMapper
             SplitAudioErrorCode.InputFileNotFound => ConsoleTexts.WithValue(ConsoleTexts.InputFileNotFoundPrefix, exception.Detail),
             SplitAudioErrorCode.OutputDirectoryCreationFailed => ConsoleTexts.WithValue(ConsoleTexts.OutputDirectoryCreationFailedPrefix, exception.Detail),
             SplitAudioErrorCode.OverwriteConflictInNonInteractive => ConsoleTexts.OverwriteConflictInNonInteractive,
+            _ => exception.Detail,
+        };
+    }
+
+    public static string ToMessage(CliException exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        return exception.ErrorCode switch
+        {
+            CliErrorCode.InputDirectoryNotFound => ConsoleTexts.WithValue(ConsoleTexts.InputDirectoryNotFoundPrefix, exception.Detail),
             _ => exception.Detail,
         };
     }

--- a/AudioSplitter.Cli/Presentation/Cli/Texts/ConsoleTexts.cs
+++ b/AudioSplitter.Cli/Presentation/Cli/Texts/ConsoleTexts.cs
@@ -5,6 +5,7 @@ namespace AudioSplitter.Cli.Presentation.Cli.Texts;
 internal static class ConsoleTexts
 {
     public const string InputFileOption = "--input-file";
+    public const string InputDirOption = "--input-dir";
     public const string OutputDirOption = "--output-dir";
     public const string LevelOption = "--level";
     public const string DurationOption = "--duration";
@@ -12,6 +13,7 @@ internal static class ConsoleTexts
     public const string ResumeOffsetOption = "--resume-offset";
     public const string ResolutionTypeOption = "--resolution-type";
     public const string FfmpegPathOption = "--ffmpeg-path";
+    public const string RecursiveOption = "--recursive";
     public const string OverwriteOption = "-y";
     public const string HelpOption = "--help";
     public const string ShortHelpOption = "-h";
@@ -24,15 +26,17 @@ internal static class ConsoleTexts
     public const string HelpText =
 """
 Usage:
-  AudioSplitter.Cli.exe --input-file <path> --output-dir <path> --level <dBFS> --duration <time> [options]
+  AudioSplitter.Cli.exe (--input-file <path> | --input-dir <path>) --output-dir <path> --level <dBFS> --duration <time> [options]
 
 Required options:
-  --input-file <path>       Input audio file path (wav/flac/alac)
+  --input-file <path>       Input audio file path (wav/flac/m4a/caf)
+  --input-dir <path>        Input directory path
   --output-dir <path>       Output directory path
   --level <dBFS>            Silence threshold in dBFS, negative value only
   --duration <time>         Silence duration threshold (e.g. 2000ms, 2s, 1m)
 
 Optional:
+  --recursive               Scan input directory recursively (available with --input-dir)
   --after-offset <time>     Keep this duration from silence start in previous segment (default: 0ms)
   --resume-offset <time>    Offset from next sound start for next segment, negative allowed (default: 0ms)
   --resolution-type <spec>  Output resolution: 16bit|24bit|32float,<rate>hz
@@ -50,7 +54,11 @@ Optional:
     public const string InvalidLevelText = "--level must be lower than 0.";
     public const string InvalidDurationText = "--duration must be greater than 0.";
     public const string InvalidAfterOffsetText = "--after-offset must be 0 or greater.";
+    public const string InputSourceRequiredText = "Specify exactly one of --input-file or --input-dir.";
+    public const string InputSourceExclusiveText = "--input-file and --input-dir cannot be specified together.";
+    public const string RecursiveRequiresInputDirText = "--recursive can only be used with --input-dir.";
     public const string InputFileNotFoundPrefix = "Input file does not exist: ";
+    public const string InputDirectoryNotFoundPrefix = "Input directory does not exist: ";
     public const string OutputDirectoryCreationFailedPrefix = "Failed to create output directory: ";
     public const string FfmpegNotFoundPrefix = "ffmpeg was not found or not executable: ";
     public const string FfprobeNotFoundPrefix = "ffprobe was not found or not executable: ";

--- a/AudioSplitter.Cli/README.md
+++ b/AudioSplitter.Cli/README.md
@@ -7,17 +7,19 @@
 ## 実行形式
 
 ```powershell
-AudioSplitter.Cli.exe --input-file <path> --output-dir <path> --level <dBFS> --duration <time> [options]
+AudioSplitter.Cli.exe (--input-file <path> | --input-dir <path>) --output-dir <path> --level <dBFS> --duration <time> [options]
 ```
 
 ## オプション
 
 | オプション | 必須 | 説明 |
 |---|---|---|
-| `--input-file <path>` | 必須 | 入力音声ファイル |
+| `--input-file <path>` | 必須（`--input-dir` と排他） | 入力音声ファイル |
+| `--input-dir <path>` | 必須（`--input-file` と排他） | 入力ディレクトリ |
 | `--output-dir <path>` | 必須 | 出力先ディレクトリ |
 | `--level <dBFS>` | 必須 | 無音判定閾値（負値） |
 | `--duration <time>` | 必須 | 無音継続時間閾値（`ms/s/m`） |
+| `--recursive` | 任意 | `--input-dir` 使用時のみ再帰走査を有効化 |
 | `--after-offset <time>` | 任意 | 無音開始後に前ファイルへ残す長さ |
 | `--resume-offset <time>` | 任意 | 次有音開始に対する次ファイル開始補正 |
 | `--resolution-type <spec>` | 任意 | `16bit|24bit|32float,<rate>hz` |
@@ -29,7 +31,10 @@ AudioSplitter.Cli.exe --input-file <path> --output-dir <path> --level <dBFS> --d
 
 - 出力形式: WAV
 - 命名規則: `{入力ファイル名}_{index:000}.wav`
+- `--input-dir` では入力ルートからの相対ディレクトリを維持
+  - 例: `/path/to/inputdir/subdir/file.wav` -> `/path/to/outputdir/subdir/file_001.wav`
 - 成功時標準出力: サマリー JSON
+  - `ProcessedFileCount`, `GeneratedCount`, `SkippedCount`, `PromptedCount`, `DetectedSegmentCount`
 - エラー時標準エラー: `{ "errors": [...] }`
 - 終了コード: 成功 `0` / 失敗 `1`
 
@@ -37,4 +42,8 @@ AudioSplitter.Cli.exe --input-file <path> --output-dir <path> --level <dBFS> --d
 
 ```powershell
 AudioSplitter.Cli.exe --input-file /path/to/file.wav --output-dir /path/to/out --level -48.0 --duration 2000ms --after-offset 500ms --resume-offset -200ms
+```
+
+```powershell
+AudioSplitter.Cli.exe --input-dir /path/to/inputdir --recursive --output-dir /path/to/outputdir --level -48.0 --duration 2000ms
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ dotnet test AudioProcessor.slnx
 
 ```powershell
 dotnet run --project AudioSplitter.Cli -- \
-  --input-file /path/to/input.flac \
+  --input-dir /path/to/inputdir \
+  --recursive \
   --output-dir /path/to/out \
   --level -48.0 \
   --duration 2000ms \

--- a/build-logs/2026-02-24T124738-input-dir-feature-build.txt
+++ b/build-logs/2026-02-24T124738-input-dir-feature-build.txt
@@ -1,0 +1,18 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+
+ビルドに成功しました。
+    0 個の警告
+    0 エラー
+
+経過時間 00:00:01.40


### PR DESCRIPTION
Fixes #3

## 背景と目的
AudioSplitter.Cli を単一ファイル入力 (`--input-file`) だけでなく、ディレクトリ入力 (`--input-dir`) にも対応させ、`--recursive` 指定時のみ再帰走査できるようにしました。

## 変更内容
- `--input-dir` と `--recursive` を追加
- `--input-file` / `--input-dir` を排他化（同時指定・未指定はパースエラー）
- `--recursive` は `--input-dir` と併用時のみ許可
- `wav/flac/m4a/caf` のみを対象にディレクトリ走査
- 入力ルートからの相対ディレクトリ構造を保持して出力
  - 例: `/path/to/inputdir/subdir/file.wav` -> `/path/to/outputdir/subdir/file_001.wav`
- 単体/ディレクトリ共通の成功サマリー (`ProcessedFileCount` を含む) を返却
- `CliException/CliErrorCode` を追加し、入力ディレクトリ未存在エラーを明示化
- `AudioSplitter.Cli.Tests` を新設し、Parser/Resolver/BatchExecutor の単体テストを追加
- README (root / AudioSplitter.Cli) を更新
- User更新済み `AGENTS.md` を同一featureブランチに反映

## 互換性影響
- 成功時 JSON に `ProcessedFileCount` が追加されます（単体モード含む）。
  - 既存4項目 (`GeneratedCount` / `SkippedCount` / `PromptedCount` / `DetectedSegmentCount`) は維持。

## 実施した検証
- `dotnet build AudioProcessor.slnx -warnaserror`
  - 0 warning / 0 error
  - ログ: `build-logs/2026-02-24T124738-input-dir-feature-build.txt`
- `dotnet test AudioProcessor.slnx`
  - 全テスト成功（AudioSplitter.Cli.Tests 14件を含む）
- `dotnet run --project AudioSplitter.Cli -- --help`
- `dotnet run --project SoundAnalyzer.Cli -- --help`

## 未対応事項
- なし