### PR TITLE
feat: add sfft-analysis mode with SFFTAnalyzer.Core

### DIFF
--- a/AudioProcessor.slnx
+++ b/AudioProcessor.slnx
@@ -7,6 +7,8 @@
   <Project Path="AudioSplitter.Core/AudioSplitter.Core.csproj" />
   <Project Path="PeakAnalyzer.Core.Tests/PeakAnalyzer.Core.Tests.csproj" />
   <Project Path="PeakAnalyzer.Core/PeakAnalyzer.Core.csproj" />
+  <Project Path="SFFTAnalyzer.Core.Tests/SFFTAnalyzer.Core.Tests.csproj" />
+  <Project Path="SFFTAnalyzer.Core/SFFTAnalyzer.Core.csproj" />
   <Project Path="SoundAnalyzer.Cli.Tests/SoundAnalyzer.Cli.Tests.csproj" />
   <Project Path="SoundAnalyzer.Cli/SoundAnalyzer.Cli.csproj" />
 </Solution>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ AudioProcessor は、オーディオ解析・変換ツール群を提供する .
 現時点では次の実行可能な機能を提供しています。
 
 - 無音区間ベース分割: `AudioSplitter.Cli`
-- 窓ピーク dB 解析 + SQLite 保存: `SoundAnalyzer.Cli`
+- 窓ピーク dB 解析 + SQLite 保存: `SoundAnalyzer.Cli --mode peak-analysis`
+- 窓SFFT解析（チャネル別band dB）+ SQLite 保存: `SoundAnalyzer.Cli --mode sfft-analysis`
 
 ## プロジェクト構成
 
@@ -15,16 +16,20 @@ AudioProcessor は、オーディオ解析・変換ツール群を提供する .
 | `AudioSplitter.Core` | Library | 無音分割ドメイン、境界計算、分割ユースケース |
 | `AudioSplitter.Cli` | CLI | 無音分割のコマンドライン実行層 |
 | `PeakAnalyzer.Core` | Library | hop/window ベースのピーク dB 窓解析コア |
+| `SFFTAnalyzer.Core` | Library | hop/window ベースの短時間FFT band解析コア |
 | `SoundAnalyzer.Cli` | CLI | ディレクトリ一括解析と SQLite 永続化 |
 | `AudioProcessor.Tests` | Test | `AudioProcessor` の単体テスト |
 | `AudioSplitter.Core.Tests` | Test | `AudioSplitter.Core` の単体テスト |
+| `AudioSplitter.Cli.Tests` | Test | `AudioSplitter.Cli` の単体テスト |
 | `PeakAnalyzer.Core.Tests` | Test | `PeakAnalyzer.Core` の単体テスト |
+| `SFFTAnalyzer.Core.Tests` | Test | `SFFTAnalyzer.Core` の単体テスト |
 | `SoundAnalyzer.Cli.Tests` | Test | `SoundAnalyzer.Cli` の単体テスト |
 
 ## 依存方向
 
 - `AudioSplitter.Cli -> AudioSplitter.Core -> AudioProcessor`
 - `SoundAnalyzer.Cli -> PeakAnalyzer.Core -> AudioProcessor`
+- `SoundAnalyzer.Cli -> SFFTAnalyzer.Core -> AudioProcessor`
 
 ## 前提環境
 
@@ -52,7 +57,7 @@ dotnet run --project AudioSplitter.Cli -- \
   --resume-offset -200ms
 ```
 
-### SoundAnalyzer.Cli
+### SoundAnalyzer.Cli (peak-analysis)
 
 ```powershell
 dotnet run --project SoundAnalyzer.Cli -- \
@@ -64,6 +69,21 @@ dotnet run --project SoundAnalyzer.Cli -- \
   --stems Piano,Drums,Vocals \
   --table-name-override T_PEAK \
   --upsert
+```
+
+### SoundAnalyzer.Cli (sfft-analysis)
+
+```powershell
+dotnet run --project SoundAnalyzer.Cli -- \
+  --window-size 50ms \
+  --hop 10ms \
+  --input-dir /path/to/dir \
+  --db-file /path/to/file.db \
+  --mode sfft-analysis \
+  --bin-count 12 \
+  --table-name-override T_SFFT \
+  --upsert \
+  --recursive
 ```
 
 ## ライセンス
@@ -96,4 +116,5 @@ dotnet run --project SoundAnalyzer.Cli -- \
 - [`AudioSplitter.Core/README.md`](AudioSplitter.Core/README.md)
 - [`AudioSplitter.Cli/README.md`](AudioSplitter.Cli/README.md)
 - [`PeakAnalyzer.Core/README.md`](PeakAnalyzer.Core/README.md)
+- [`SFFTAnalyzer.Core/README.md`](SFFTAnalyzer.Core/README.md)
 - [`SoundAnalyzer.Cli/README.md`](SoundAnalyzer.Cli/README.md)

--- a/SFFTAnalyzer.Core.Tests/Application/SfftAnalysisUseCaseTests.cs
+++ b/SFFTAnalyzer.Core.Tests/Application/SfftAnalysisUseCaseTests.cs
@@ -1,0 +1,305 @@
+using AudioProcessor.Application.Models;
+using AudioProcessor.Application.Ports;
+using AudioProcessor.Domain.Models;
+using SFFTAnalyzer.Core.Application.Models;
+using SFFTAnalyzer.Core.Application.Ports;
+using SFFTAnalyzer.Core.Application.UseCases;
+using SFFTAnalyzer.Core.Domain.Models;
+
+namespace SFFTAnalyzer.Core.Tests.Application;
+
+public sealed class SfftAnalysisUseCaseTests
+{
+    [Fact]
+    public async Task ExecuteAsync_ShouldStartAnchorsAtHopMs()
+    {
+        string inputPath = CreateTempInputFile();
+        try
+        {
+            float[][] frames = CreateFrames(channels: 1, count: 100, value: 0.2F);
+            SfftAnalysisUseCase useCase = BuildUseCase(sampleRate: 1000, channels: 1, frames);
+            CollectingWriter writer = new();
+
+            SfftAnalysisRequest request = new(
+                inputPath,
+                "song",
+                windowSizeMs: 50,
+                hopMs: 10,
+                binCount: 12,
+                minLimitDb: -120,
+                ffmpegPath: null);
+
+            SfftAnalysisSummary summary = await useCase.ExecuteAsync(request, writer, CancellationToken.None);
+
+            Assert.Equal(10, writer.Points[0].Ms);
+            Assert.DoesNotContain(writer.Points, point => point.Ms == 0);
+            Assert.Equal(10, summary.PointCount);
+        }
+        finally
+        {
+            File.Delete(inputPath);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldEmitForEarlyAnchorsByPaddingWithSilence()
+    {
+        string inputPath = CreateTempInputFile();
+        try
+        {
+            float[][] frames = CreateFrames(channels: 1, count: 10, value: 0.0F);
+            frames[0][0] = 1.0F;
+
+            SfftAnalysisUseCase useCase = BuildUseCase(sampleRate: 1000, channels: 1, frames);
+            CollectingWriter writer = new();
+
+            SfftAnalysisRequest request = new(
+                inputPath,
+                "song",
+                windowSizeMs: 50,
+                hopMs: 10,
+                binCount: 8,
+                minLimitDb: -120,
+                ffmpegPath: null);
+
+            SfftAnalysisSummary summary = await useCase.ExecuteAsync(request, writer, CancellationToken.None);
+
+            Assert.Equal(1, summary.PointCount);
+            Assert.Single(writer.Points);
+            Assert.Equal(10, writer.Points[0].Ms);
+            Assert.Equal(8, writer.Points[0].Bins.Count);
+        }
+        finally
+        {
+            File.Delete(inputPath);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldDropTailRemainderFrames()
+    {
+        string inputPath = CreateTempInputFile();
+        try
+        {
+            float[][] frames = CreateFrames(channels: 1, count: 10_233, value: 0.0F);
+            SfftAnalysisUseCase useCase = BuildUseCase(sampleRate: 1000, channels: 1, frames);
+            CollectingWriter writer = new();
+
+            SfftAnalysisRequest request = new(
+                inputPath,
+                "song",
+                windowSizeMs: 50,
+                hopMs: 10,
+                binCount: 6,
+                minLimitDb: -120,
+                ffmpegPath: null);
+
+            SfftAnalysisSummary summary = await useCase.ExecuteAsync(request, writer, CancellationToken.None);
+
+            Assert.Equal(1023, summary.PointCount);
+            Assert.Equal(10_230, summary.LastMs);
+            Assert.Equal(10_230, writer.Points[^1].Ms);
+        }
+        finally
+        {
+            File.Delete(inputPath);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldEmitRowsPerChannel()
+    {
+        string inputPath = CreateTempInputFile();
+        try
+        {
+            float[][] frames = CreateFrames(channels: 2, count: 20, value: 0.0F);
+            frames[10][0] = 0.5F;
+            frames[10][1] = 0.1F;
+
+            SfftAnalysisUseCase useCase = BuildUseCase(sampleRate: 1000, channels: 2, frames);
+            CollectingWriter writer = new();
+
+            SfftAnalysisRequest request = new(
+                inputPath,
+                "song",
+                windowSizeMs: 20,
+                hopMs: 20,
+                binCount: 4,
+                minLimitDb: -120,
+                ffmpegPath: null);
+
+            SfftAnalysisSummary summary = await useCase.ExecuteAsync(request, writer, CancellationToken.None);
+
+            Assert.Equal(2, summary.PointCount);
+            Assert.Equal(2, writer.Points.Count);
+            Assert.Contains(writer.Points, point => point.Channel == 0);
+            Assert.Contains(writer.Points, point => point.Channel == 1);
+            Assert.All(writer.Points, point => Assert.Equal(4, point.Bins.Count));
+        }
+        finally
+        {
+            File.Delete(inputPath);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldEmitConfiguredBinCount()
+    {
+        string inputPath = CreateTempInputFile();
+        try
+        {
+            float[][] frames = CreateFrames(channels: 1, count: 50, value: 0.2F);
+            SfftAnalysisUseCase useCase = BuildUseCase(sampleRate: 1000, channels: 1, frames);
+            CollectingWriter writer = new();
+
+            SfftAnalysisRequest request = new(
+                inputPath,
+                "song",
+                windowSizeMs: 25,
+                hopMs: 10,
+                binCount: 12,
+                minLimitDb: -120,
+                ffmpegPath: null);
+
+            _ = await useCase.ExecuteAsync(request, writer, CancellationToken.None);
+
+            Assert.All(writer.Points, point => Assert.Equal(12, point.Bins.Count));
+        }
+        finally
+        {
+            File.Delete(inputPath);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldClampBinsByMinLimit()
+    {
+        string inputPath = CreateTempInputFile();
+        try
+        {
+            float[][] frames = CreateFrames(channels: 1, count: 20, value: 0.0F);
+            SfftAnalysisUseCase useCase = BuildUseCase(sampleRate: 1000, channels: 1, frames);
+            CollectingWriter writer = new();
+
+            SfftAnalysisRequest request = new(
+                inputPath,
+                "song",
+                windowSizeMs: 20,
+                hopMs: 10,
+                binCount: 8,
+                minLimitDb: -40,
+                ffmpegPath: null);
+
+            _ = await useCase.ExecuteAsync(request, writer, CancellationToken.None);
+
+            Assert.All(
+                writer.Points,
+                point => Assert.All(point.Bins, value => Assert.Equal(-40, value, precision: 6)));
+        }
+        finally
+        {
+            File.Delete(inputPath);
+        }
+    }
+
+    private static float[][] CreateFrames(int channels, int count, float value)
+    {
+        float[][] frames = new float[count][];
+        for (int i = 0; i < count; i++)
+        {
+            float[] frame = new float[channels];
+            for (int channel = 0; channel < channels; channel++)
+            {
+                frame[channel] = value;
+            }
+
+            frames[i] = frame;
+        }
+
+        return frames;
+    }
+
+    private static SfftAnalysisUseCase BuildUseCase(int sampleRate, int channels, float[][] frames)
+    {
+        AudioStreamInfo streamInfo = new(sampleRate, channels, AudioPcmBitDepth.F32, frames.Length);
+        return new SfftAnalysisUseCase(
+            new FakeFfmpegLocator(),
+            new FakeProbeService(streamInfo),
+            new FakePcmFrameReader(frames));
+    }
+
+    private static string CreateTempInputFile()
+    {
+        string path = Path.GetTempFileName();
+        using FileStream stream = File.Open(path, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
+        stream.WriteByte(0);
+        return path;
+    }
+
+    private sealed class FakeFfmpegLocator : IFfmpegLocator
+    {
+        public FfmpegToolPaths Resolve(string? ffmpegPath)
+        {
+            return new FfmpegToolPaths("ffmpeg", "ffprobe");
+        }
+    }
+
+    private sealed class FakeProbeService : IAudioProbeService
+    {
+        private readonly AudioStreamInfo streamInfo;
+
+        public FakeProbeService(AudioStreamInfo streamInfo)
+        {
+            this.streamInfo = streamInfo ?? throw new ArgumentNullException(nameof(streamInfo));
+        }
+
+        public Task<AudioStreamInfo> ProbeAsync(
+            FfmpegToolPaths toolPaths,
+            string inputFilePath,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(streamInfo);
+        }
+    }
+
+    private sealed class FakePcmFrameReader : IAudioPcmFrameReader
+    {
+        private readonly IReadOnlyList<float[]> frames;
+
+        public FakePcmFrameReader(IReadOnlyList<float[]> frames)
+        {
+            this.frames = frames ?? throw new ArgumentNullException(nameof(frames));
+        }
+
+        public Task ReadFramesAsync(
+            FfmpegToolPaths toolPaths,
+            string inputFilePath,
+            int channels,
+            IAudioPcmFrameSink frameSink,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(frameSink);
+
+            for (int i = 0; i < frames.Count; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                float[] frame = frames[i];
+                Assert.Equal(channels, frame.Length);
+                frameSink.OnFrame(frame);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class CollectingWriter : ISfftAnalysisPointWriter
+    {
+        public List<SfftAnalysisPoint> Points { get; } = new();
+
+        public void Write(SfftAnalysisPoint point)
+        {
+            ArgumentNullException.ThrowIfNull(point);
+            Points.Add(point);
+        }
+    }
+}

--- a/SFFTAnalyzer.Core.Tests/SFFTAnalyzer.Core.Tests.csproj
+++ b/SFFTAnalyzer.Core.Tests/SFFTAnalyzer.Core.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SFFTAnalyzer.Core\SFFTAnalyzer.Core.csproj" />
+    <ProjectReference Include="..\AudioProcessor\AudioProcessor.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Application\**\*.cs" />
+  </ItemGroup>
+
+</Project>

--- a/SFFTAnalyzer.Core/Application/Errors/SfftAnalysisErrorCode.cs
+++ b/SFFTAnalyzer.Core/Application/Errors/SfftAnalysisErrorCode.cs
@@ -1,0 +1,11 @@
+namespace SFFTAnalyzer.Core.Application.Errors;
+
+public enum SfftAnalysisErrorCode
+{
+    None = 0,
+    InputFileNotFound,
+    InvalidWindowSize,
+    InvalidHop,
+    InvalidBinCount,
+    InvalidMinLimitDb,
+}

--- a/SFFTAnalyzer.Core/Application/Errors/SfftAnalysisException.cs
+++ b/SFFTAnalyzer.Core/Application/Errors/SfftAnalysisException.cs
@@ -1,0 +1,39 @@
+namespace SFFTAnalyzer.Core.Application.Errors;
+
+#pragma warning disable S3871
+public sealed class SfftAnalysisException : Exception
+{
+    public SfftAnalysisException()
+        : this(SfftAnalysisErrorCode.None, string.Empty)
+    {
+    }
+
+    public SfftAnalysisException(string message)
+        : this(SfftAnalysisErrorCode.None, message)
+    {
+    }
+
+    public SfftAnalysisException(string message, Exception innerException)
+        : this(SfftAnalysisErrorCode.None, message, innerException)
+    {
+    }
+
+    public SfftAnalysisException(SfftAnalysisErrorCode errorCode, string detail)
+        : base(detail)
+    {
+        ErrorCode = errorCode;
+        Detail = detail;
+    }
+
+    public SfftAnalysisException(SfftAnalysisErrorCode errorCode, string detail, Exception innerException)
+        : base(detail, innerException)
+    {
+        ErrorCode = errorCode;
+        Detail = detail;
+    }
+
+    public SfftAnalysisErrorCode ErrorCode { get; }
+
+    public string Detail { get; }
+}
+#pragma warning restore S3871

--- a/SFFTAnalyzer.Core/Application/Models/SfftAnalysisRequest.cs
+++ b/SFFTAnalyzer.Core/Application/Models/SfftAnalysisRequest.cs
@@ -1,0 +1,47 @@
+namespace SFFTAnalyzer.Core.Application.Models;
+
+public sealed class SfftAnalysisRequest
+{
+    public SfftAnalysisRequest(
+        string inputFilePath,
+        string name,
+        long windowSizeMs,
+        long hopMs,
+        int binCount,
+        double minLimitDb,
+        string? ffmpegPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(inputFilePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(windowSizeMs);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(hopMs);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(binCount);
+
+        if (double.IsNaN(minLimitDb) || double.IsInfinity(minLimitDb))
+        {
+            throw new ArgumentOutOfRangeException(nameof(minLimitDb));
+        }
+
+        InputFilePath = inputFilePath;
+        Name = name;
+        WindowSizeMs = windowSizeMs;
+        HopMs = hopMs;
+        BinCount = binCount;
+        MinLimitDb = minLimitDb;
+        FfmpegPath = ffmpegPath;
+    }
+
+    public string InputFilePath { get; }
+
+    public string Name { get; }
+
+    public long WindowSizeMs { get; }
+
+    public long HopMs { get; }
+
+    public int BinCount { get; }
+
+    public double MinLimitDb { get; }
+
+    public string? FfmpegPath { get; }
+}

--- a/SFFTAnalyzer.Core/Application/Ports/ISfftAnalysisPointWriter.cs
+++ b/SFFTAnalyzer.Core/Application/Ports/ISfftAnalysisPointWriter.cs
@@ -1,0 +1,8 @@
+using SFFTAnalyzer.Core.Domain.Models;
+
+namespace SFFTAnalyzer.Core.Application.Ports;
+
+public interface ISfftAnalysisPointWriter
+{
+    public void Write(SfftAnalysisPoint point);
+}

--- a/SFFTAnalyzer.Core/Application/UseCases/SfftAnalysisUseCase.cs
+++ b/SFFTAnalyzer.Core/Application/UseCases/SfftAnalysisUseCase.cs
@@ -1,0 +1,96 @@
+using System.Globalization;
+using AudioProcessor.Application.Models;
+using AudioProcessor.Application.Ports;
+using AudioProcessor.Domain.Models;
+using SFFTAnalyzer.Core.Application.Errors;
+using SFFTAnalyzer.Core.Application.Models;
+using SFFTAnalyzer.Core.Application.Ports;
+using SFFTAnalyzer.Core.Domain.Models;
+using SFFTAnalyzer.Core.Infrastructure.Analysis;
+
+namespace SFFTAnalyzer.Core.Application.UseCases;
+
+public sealed class SfftAnalysisUseCase
+{
+    private readonly IFfmpegLocator ffmpegLocator;
+    private readonly IAudioProbeService audioProbeService;
+    private readonly IAudioPcmFrameReader pcmFrameReader;
+
+    public SfftAnalysisUseCase(
+        IFfmpegLocator ffmpegLocator,
+        IAudioProbeService audioProbeService,
+        IAudioPcmFrameReader pcmFrameReader)
+    {
+        this.ffmpegLocator = ffmpegLocator ?? throw new ArgumentNullException(nameof(ffmpegLocator));
+        this.audioProbeService = audioProbeService ?? throw new ArgumentNullException(nameof(audioProbeService));
+        this.pcmFrameReader = pcmFrameReader ?? throw new ArgumentNullException(nameof(pcmFrameReader));
+    }
+
+    public async Task<SfftAnalysisSummary> ExecuteAsync(
+        SfftAnalysisRequest request,
+        ISfftAnalysisPointWriter pointWriter,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(pointWriter);
+
+        if (!File.Exists(request.InputFilePath))
+        {
+            throw new SfftAnalysisException(SfftAnalysisErrorCode.InputFileNotFound, request.InputFilePath);
+        }
+
+        if (request.WindowSizeMs <= 0)
+        {
+            throw new SfftAnalysisException(
+                SfftAnalysisErrorCode.InvalidWindowSize,
+                request.WindowSizeMs.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (request.HopMs <= 0)
+        {
+            throw new SfftAnalysisException(
+                SfftAnalysisErrorCode.InvalidHop,
+                request.HopMs.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (request.BinCount <= 0)
+        {
+            throw new SfftAnalysisException(
+                SfftAnalysisErrorCode.InvalidBinCount,
+                request.BinCount.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (double.IsNaN(request.MinLimitDb) || double.IsInfinity(request.MinLimitDb))
+        {
+            throw new SfftAnalysisException(
+                SfftAnalysisErrorCode.InvalidMinLimitDb,
+                request.MinLimitDb.ToString(CultureInfo.InvariantCulture));
+        }
+
+        FfmpegToolPaths toolPaths = ffmpegLocator.Resolve(request.FfmpegPath);
+        AudioStreamInfo streamInfo = await audioProbeService
+            .ProbeAsync(toolPaths, request.InputFilePath, cancellationToken)
+            .ConfigureAwait(false);
+
+        SfftWindowAnalyzer analyzer = new(
+            streamInfo.SampleRate,
+            streamInfo.Channels,
+            request.Name,
+            request.WindowSizeMs,
+            request.HopMs,
+            request.BinCount,
+            request.MinLimitDb,
+            pointWriter);
+
+        await pcmFrameReader
+            .ReadFramesAsync(
+                toolPaths,
+                request.InputFilePath,
+                streamInfo.Channels,
+                analyzer,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return analyzer.BuildSummary();
+    }
+}

--- a/SFFTAnalyzer.Core/Domain/Models/SfftAnalysisPoint.cs
+++ b/SFFTAnalyzer.Core/Domain/Models/SfftAnalysisPoint.cs
@@ -1,0 +1,48 @@
+namespace SFFTAnalyzer.Core.Domain.Models;
+
+public sealed class SfftAnalysisPoint
+{
+    public SfftAnalysisPoint(
+        string name,
+        int channel,
+        long windowMs,
+        long ms,
+        IReadOnlyList<double> bins)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentOutOfRangeException.ThrowIfNegative(channel);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(windowMs);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(ms);
+        ArgumentNullException.ThrowIfNull(bins);
+
+        if (bins.Count == 0)
+        {
+            throw new ArgumentException("At least one bin is required.", nameof(bins));
+        }
+
+        for (int i = 0; i < bins.Count; i++)
+        {
+            double value = bins[i];
+            if (double.IsNaN(value) || double.IsInfinity(value))
+            {
+                throw new ArgumentOutOfRangeException(nameof(bins));
+            }
+        }
+
+        Name = name;
+        Channel = channel;
+        WindowMs = windowMs;
+        Ms = ms;
+        Bins = bins;
+    }
+
+    public string Name { get; }
+
+    public int Channel { get; }
+
+    public long WindowMs { get; }
+
+    public long Ms { get; }
+
+    public IReadOnlyList<double> Bins { get; }
+}

--- a/SFFTAnalyzer.Core/Domain/Models/SfftAnalysisSummary.cs
+++ b/SFFTAnalyzer.Core/Domain/Models/SfftAnalysisSummary.cs
@@ -1,0 +1,21 @@
+namespace SFFTAnalyzer.Core.Domain.Models;
+
+public sealed class SfftAnalysisSummary
+{
+    public SfftAnalysisSummary(int pointCount, long totalFrames, long lastMs)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(pointCount);
+        ArgumentOutOfRangeException.ThrowIfNegative(totalFrames);
+        ArgumentOutOfRangeException.ThrowIfNegative(lastMs);
+
+        PointCount = pointCount;
+        TotalFrames = totalFrames;
+        LastMs = lastMs;
+    }
+
+    public int PointCount { get; }
+
+    public long TotalFrames { get; }
+
+    public long LastMs { get; }
+}

--- a/SFFTAnalyzer.Core/Extensions/SfftAnalyzerCoreServiceCollectionExtensions.cs
+++ b/SFFTAnalyzer.Core/Extensions/SfftAnalyzerCoreServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+using AudioProcessor.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using SFFTAnalyzer.Core.Application.UseCases;
+
+namespace SFFTAnalyzer.Core.Extensions;
+
+public static class SfftAnalyzerCoreServiceCollectionExtensions
+{
+    public static IServiceCollection AddSfftAnalyzerCore(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddAudioProcessor();
+        services.AddSingleton<SfftAnalysisUseCase>();
+
+        return services;
+    }
+}

--- a/SFFTAnalyzer.Core/Infrastructure/Analysis/SfftWindowAnalyzer.cs
+++ b/SFFTAnalyzer.Core/Infrastructure/Analysis/SfftWindowAnalyzer.cs
@@ -1,0 +1,337 @@
+using AudioProcessor.Application.Ports;
+using SFFTAnalyzer.Core.Application.Ports;
+using SFFTAnalyzer.Core.Domain.Models;
+
+namespace SFFTAnalyzer.Core.Infrastructure.Analysis;
+
+internal sealed class SfftWindowAnalyzer : IAudioPcmFrameSink
+{
+    private readonly int sampleRate;
+    private readonly int channels;
+    private readonly string name;
+    private readonly long windowMs;
+    private readonly long hopMs;
+    private readonly int binCount;
+    private readonly double minLimitDb;
+    private readonly ISfftAnalysisPointWriter pointWriter;
+
+    private readonly long windowFrames;
+    private readonly int windowFrameCount;
+    private readonly int ringLength;
+    private readonly double[][] channelRingBuffers;
+    private readonly double[] hannWindow;
+    private readonly int positiveFrequencyBinCount;
+
+    private readonly double[] fftReal;
+    private readonly double[] fftImag;
+
+    private long frameIndex;
+    private int pointCount;
+    private long lastMs;
+    private long nextAnchorMs;
+
+    public SfftWindowAnalyzer(
+        int sampleRate,
+        int channels,
+        string name,
+        long windowMs,
+        long hopMs,
+        int binCount,
+        double minLimitDb,
+        ISfftAnalysisPointWriter pointWriter)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(sampleRate);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(channels);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(windowMs);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(hopMs);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(binCount);
+        ArgumentNullException.ThrowIfNull(pointWriter);
+
+        this.sampleRate = sampleRate;
+        this.channels = channels;
+        this.name = name;
+        this.windowMs = windowMs;
+        this.hopMs = hopMs;
+        this.binCount = binCount;
+        this.minLimitDb = minLimitDb;
+        this.pointWriter = pointWriter;
+
+        long calculatedWindowFrames = TimeMsToFrameFloor(windowMs, sampleRate);
+        this.windowFrames = Math.Max(1, calculatedWindowFrames);
+
+        if (this.windowFrames > int.MaxValue - 2)
+        {
+            throw new ArgumentOutOfRangeException(nameof(windowMs), "Window size is too large.");
+        }
+
+        windowFrameCount = checked((int)this.windowFrames);
+        ringLength = checked(windowFrameCount + 2);
+
+        channelRingBuffers = new double[channels][];
+        for (int channel = 0; channel < channels; channel++)
+        {
+            channelRingBuffers[channel] = new double[ringLength];
+        }
+
+        hannWindow = BuildHannWindow(windowFrameCount);
+        int fftLength = NextPowerOfTwo(windowFrameCount);
+        positiveFrequencyBinCount = (fftLength / 2) + 1;
+
+        fftReal = new double[fftLength];
+        fftImag = new double[fftLength];
+
+        nextAnchorMs = hopMs;
+    }
+
+    public void OnFrame(ReadOnlySpan<float> frameSamples)
+    {
+        if (frameSamples.Length != channels)
+        {
+            throw new ArgumentException("Unexpected channel count.", nameof(frameSamples));
+        }
+
+        int writeIndex = checked((int)(frameIndex % ringLength));
+        for (int channel = 0; channel < channels; channel++)
+        {
+            channelRingBuffers[channel][writeIndex] = frameSamples[channel];
+        }
+
+        frameIndex++;
+
+        long elapsedMs = FrameToElapsedMsFloor(frameIndex, sampleRate);
+        while (nextAnchorMs <= elapsedMs)
+        {
+            EmitPoint(nextAnchorMs);
+            nextAnchorMs += hopMs;
+        }
+    }
+
+    public SfftAnalysisSummary BuildSummary()
+    {
+        return new SfftAnalysisSummary(pointCount, frameIndex, lastMs);
+    }
+
+    private void EmitPoint(long anchorMs)
+    {
+        long endFrameExclusive = TimeMsToFrameFloor(anchorMs, sampleRate);
+        long startFrame = endFrameExclusive - windowFrames;
+
+        for (int channel = 0; channel < channels; channel++)
+        {
+            LoadWindow(channel, startFrame);
+            FftMath.TransformInPlace(fftReal, fftImag);
+
+            double[] bins = BuildBandValues();
+            SfftAnalysisPoint point = new(name, channel, windowMs, anchorMs, bins);
+            pointWriter.Write(point);
+            pointCount++;
+        }
+
+        lastMs = anchorMs;
+    }
+
+    private void LoadWindow(int channel, long startFrame)
+    {
+        Array.Clear(fftReal, 0, fftReal.Length);
+        Array.Clear(fftImag, 0, fftImag.Length);
+
+        for (int offset = 0; offset < windowFrameCount; offset++)
+        {
+            long sourceFrame = startFrame + offset;
+            double sample = sourceFrame < 0 ? 0 : ReadBufferedSample(channel, sourceFrame);
+            fftReal[offset] = sample * hannWindow[offset];
+        }
+    }
+
+    private double[] BuildBandValues()
+    {
+        double[] bins = new double[binCount];
+
+        for (int band = 0; band < binCount; band++)
+        {
+            int bandStart = checked((int)((long)band * positiveFrequencyBinCount / binCount));
+            int bandEnd = checked((int)((long)(band + 1) * positiveFrequencyBinCount / binCount));
+
+            if (bandEnd <= bandStart)
+            {
+                bandEnd = Math.Min(positiveFrequencyBinCount, bandStart + 1);
+            }
+
+            if (band == binCount - 1)
+            {
+                bandEnd = positiveFrequencyBinCount;
+            }
+
+            double sumMagnitude = 0;
+            int count = 0;
+
+            for (int frequency = bandStart; frequency < bandEnd; frequency++)
+            {
+                double real = fftReal[frequency];
+                double imag = fftImag[frequency];
+                double magnitude = Math.Sqrt((real * real) + (imag * imag));
+                sumMagnitude += magnitude;
+                count++;
+            }
+
+            double averageMagnitude = count == 0 ? 0 : sumMagnitude / count;
+            double db = averageMagnitude <= 0 ? double.NegativeInfinity : 20 * Math.Log10(averageMagnitude);
+            if (db < minLimitDb)
+            {
+                db = minLimitDb;
+            }
+
+            bins[band] = db;
+        }
+
+        return bins;
+    }
+
+    private double ReadBufferedSample(int channel, long sourceFrame)
+    {
+        if (sourceFrame < 0)
+        {
+            return 0;
+        }
+
+        if (sourceFrame >= frameIndex)
+        {
+            return 0;
+        }
+
+        long oldestRetainedFrame = Math.Max(0, frameIndex - ringLength);
+        if (sourceFrame < oldestRetainedFrame)
+        {
+            throw new InvalidOperationException("Insufficient buffer for requested frame window.");
+        }
+
+        int index = checked((int)(sourceFrame % ringLength));
+        return channelRingBuffers[channel][index];
+    }
+
+    private static double[] BuildHannWindow(int sampleCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(sampleCount);
+
+        if (sampleCount == 1)
+        {
+            return [1.0];
+        }
+
+        double[] window = new double[sampleCount];
+        for (int i = 0; i < sampleCount; i++)
+        {
+            window[i] = 0.5 * (1 - Math.Cos(2 * Math.PI * i / (sampleCount - 1)));
+        }
+
+        return window;
+    }
+
+    private static int NextPowerOfTwo(int value)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+
+        int result = 1;
+        while (result < value)
+        {
+            if (result > int.MaxValue / 2)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "FFT size is too large.");
+            }
+
+            result <<= 1;
+        }
+
+        return result;
+    }
+
+    private static long FrameToElapsedMsFloor(long frameCount, int sampleRate)
+    {
+        return checked(frameCount * 1000 / sampleRate);
+    }
+
+    private static long TimeMsToFrameFloor(long ms, int sampleRate)
+    {
+        return checked(ms * sampleRate / 1000);
+    }
+
+    private static class FftMath
+    {
+        public static void TransformInPlace(double[] real, double[] imag)
+        {
+            ArgumentNullException.ThrowIfNull(real);
+            ArgumentNullException.ThrowIfNull(imag);
+
+            if (real.Length != imag.Length)
+            {
+                throw new ArgumentException("Real and imaginary arrays must have same length.");
+            }
+
+            int length = real.Length;
+            if (length == 0 || (length & (length - 1)) != 0)
+            {
+                throw new ArgumentException("FFT length must be a power of two.");
+            }
+
+            BitReverse(real, imag);
+
+            for (int blockSize = 2; blockSize <= length; blockSize <<= 1)
+            {
+                int halfSize = blockSize / 2;
+                double theta = -2 * Math.PI / blockSize;
+                double phaseStepReal = Math.Cos(theta);
+                double phaseStepImag = Math.Sin(theta);
+
+                for (int start = 0; start < length; start += blockSize)
+                {
+                    double phaseReal = 1;
+                    double phaseImag = 0;
+
+                    for (int offset = 0; offset < halfSize; offset++)
+                    {
+                        int evenIndex = start + offset;
+                        int oddIndex = evenIndex + halfSize;
+
+                        double oddReal = (real[oddIndex] * phaseReal) - (imag[oddIndex] * phaseImag);
+                        double oddImag = (real[oddIndex] * phaseImag) + (imag[oddIndex] * phaseReal);
+
+                        real[oddIndex] = real[evenIndex] - oddReal;
+                        imag[oddIndex] = imag[evenIndex] - oddImag;
+                        real[evenIndex] += oddReal;
+                        imag[evenIndex] += oddImag;
+
+                        double nextPhaseReal = (phaseReal * phaseStepReal) - (phaseImag * phaseStepImag);
+                        double nextPhaseImag = (phaseReal * phaseStepImag) + (phaseImag * phaseStepReal);
+                        phaseReal = nextPhaseReal;
+                        phaseImag = nextPhaseImag;
+                    }
+                }
+            }
+        }
+
+        private static void BitReverse(double[] real, double[] imag)
+        {
+            int n = real.Length;
+            int j = 0;
+
+            for (int i = 1; i < n; i++)
+            {
+                int bit = n >> 1;
+                while ((j & bit) != 0)
+                {
+                    j ^= bit;
+                    bit >>= 1;
+                }
+
+                j ^= bit;
+
+                if (i < j)
+                {
+                    (real[i], real[j]) = (real[j], real[i]);
+                    (imag[i], imag[j]) = (imag[j], imag[i]);
+                }
+            }
+        }
+    }
+}

--- a/SFFTAnalyzer.Core/README.md
+++ b/SFFTAnalyzer.Core/README.md
@@ -1,0 +1,31 @@
+# SFFTAnalyzer.Core
+
+## 役割
+`SFFTAnalyzer.Core` は、単一音源を hop/window 単位で短時間FFT解析し、
+各時間窓に対するチャネル別スペクトルバンド（dB）を出力するコアライブラリです。
+
+## 主要契約
+
+- `SfftAnalysisUseCase`
+- `SfftAnalysisRequest`
+- `SfftAnalysisPoint`
+- `SfftAnalysisSummary`
+- `ISfftAnalysisPointWriter`
+- `SfftAnalysisException`
+
+## 解析ルール
+
+- 解析アンカーは `hop` ごと
+- 最初のアンカーは `hop ms`（`0ms` は解析しない）
+- 窓区間は `[t-window, t)`
+- 先頭不足区間は無音（0）として扱う
+- 末尾は `floor(total_ms / hop_ms) * hop_ms` までを対象とし端数は破棄
+- チャネルは分離して解析する（`ch=0..n-1`）
+- FFT入力には Hann 窓を適用する
+- 正周波数 `0..Nyquist` を `binCount` 等分し、帯域平均 magnitude を dB 化する
+- `min-limit-db` で下限クランプする
+
+## 責務分離
+
+`SfftAnalysisUseCase` は解析実行を担当し、解析結果の永続化・出力は
+`ISfftAnalysisPointWriter` 実装に委譲します。

--- a/SFFTAnalyzer.Core/SFFTAnalyzer.Core.csproj
+++ b/SFFTAnalyzer.Core/SFFTAnalyzer.Core.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\AudioProcessor\AudioProcessor.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Application\**\*.cs" />
+    <Compile Include="Domain\**\*.cs" />
+    <Compile Include="Infrastructure\**\*.cs" />
+    <Compile Include="Extensions\**\*.cs" />
+  </ItemGroup>
+
+</Project>

--- a/SoundAnalyzer.Cli.Tests/Infrastructure/FileSystem/SfftAudioFileResolverTests.cs
+++ b/SoundAnalyzer.Cli.Tests/Infrastructure/FileSystem/SfftAudioFileResolverTests.cs
@@ -1,0 +1,116 @@
+using SoundAnalyzer.Cli.Infrastructure.Execution;
+using SoundAnalyzer.Cli.Infrastructure.FileSystem;
+
+namespace SoundAnalyzer.Cli.Tests.Infrastructure.FileSystem;
+
+public sealed class SfftAudioFileResolverTests
+{
+    [Fact]
+    public void Resolve_ShouldScanOnlyTopDirectoryFiles_WhenRecursiveIsFalse()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            string topFile = Path.Combine(root, "Top.wav");
+            File.WriteAllText(topFile, "top");
+
+            string subDirectory = Path.Combine(root, "Sub");
+            Directory.CreateDirectory(subDirectory);
+            File.WriteAllText(Path.Combine(subDirectory, "Nested.wav"), "nested");
+
+            ResolvedSfftAudioFiles resolved = SfftAudioFileResolver.Resolve(root, recursive: false);
+
+            Assert.Single(resolved.Files);
+            Assert.Equal("Top", resolved.Files[0].Name, StringComparer.Ordinal);
+            Assert.Equal(topFile, resolved.Files[0].FilePath, ignoreCase: true);
+            Assert.Equal(1, resolved.DirectoryCount);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Resolve_ShouldScanRecursively_WhenRecursiveIsTrue()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            string topFile = Path.Combine(root, "Top.wav");
+            File.WriteAllText(topFile, "top");
+
+            string subDirectory = Path.Combine(root, "Sub");
+            Directory.CreateDirectory(subDirectory);
+            string nestedFile = Path.Combine(subDirectory, "Nested.flac");
+            File.WriteAllText(nestedFile, "nested");
+
+            ResolvedSfftAudioFiles resolved = SfftAudioFileResolver.Resolve(root, recursive: true);
+
+            Assert.Equal(2, resolved.Files.Count);
+            Assert.Contains(resolved.Files, file => string.Equals(file.Name, "Top", StringComparison.Ordinal));
+            Assert.Contains(resolved.Files, file => string.Equals(file.Name, "Nested", StringComparison.Ordinal));
+            Assert.True(resolved.DirectoryCount >= 2);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Resolve_ShouldApplyExtensionPriority_ForSameBasenameInSameDirectory()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            string flacPath = Path.Combine(root, "Song.flac");
+            string wavPath = Path.Combine(root, "Song.wav");
+            File.WriteAllText(flacPath, "flac");
+            File.WriteAllText(wavPath, "wav");
+
+            ResolvedSfftAudioFiles resolved = SfftAudioFileResolver.Resolve(root, recursive: false);
+
+            Assert.Single(resolved.Files);
+            Assert.Equal("Song", resolved.Files[0].Name, StringComparer.Ordinal);
+            Assert.Equal(wavPath, resolved.Files[0].FilePath, ignoreCase: true);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Resolve_ShouldFail_WhenDuplicateNamesExistAcrossInputSet_CaseInsensitive()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            string topPath = Path.Combine(root, "Song.wav");
+            File.WriteAllText(topPath, "top");
+
+            string subDirectory = Path.Combine(root, "Sub");
+            Directory.CreateDirectory(subDirectory);
+            string nestedPath = Path.Combine(subDirectory, "song.flac");
+            File.WriteAllText(nestedPath, "nested");
+
+            CliException exception = Assert.Throws<CliException>(
+                () => SfftAudioFileResolver.Resolve(root, recursive: true));
+
+            Assert.Equal(CliErrorCode.DuplicateSfftAnalysisName, exception.ErrorCode);
+            Assert.Equal("song", exception.Detail, ignoreCase: true);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static string CreateTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"sound-analyzer-sfft-resolver-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/SoundAnalyzer.Cli.Tests/Infrastructure/Sqlite/SqliteSfftAnalysisStoreTests.cs
+++ b/SoundAnalyzer.Cli.Tests/Infrastructure/Sqlite/SqliteSfftAnalysisStoreTests.cs
@@ -1,0 +1,299 @@
+using Microsoft.Data.Sqlite;
+using SFFTAnalyzer.Core.Domain.Models;
+using SoundAnalyzer.Cli.Infrastructure.Execution;
+using SoundAnalyzer.Cli.Infrastructure.Sqlite;
+
+namespace SoundAnalyzer.Cli.Tests.Infrastructure.Sqlite;
+
+public sealed class SqliteSfftAnalysisStoreTests
+{
+    [Fact]
+    public void Initialize_ShouldCreateTable_WhenDatabaseDoesNotExist()
+    {
+        string dbFilePath = CreateTempDbPath();
+        try
+        {
+            using (SqliteSfftAnalysisStore store = new(
+                       dbFilePath,
+                       "T_SFFTAnalysis",
+                       SqliteConflictMode.Error,
+                       binCount: 12,
+                       deleteCurrent: false))
+            {
+                store.Initialize();
+                store.Complete();
+            }
+
+            Assert.True(File.Exists(dbFilePath));
+            Assert.True(TableExists(dbFilePath, "T_SFFTAnalysis"));
+            Assert.Equal(12, CountBinColumns(dbFilePath));
+        }
+        finally
+        {
+            DeleteIfExists(dbFilePath);
+        }
+    }
+
+    [Fact]
+    public void Initialize_ShouldFail_WhenExistingTableBinCountDiffers()
+    {
+        string dbFilePath = CreateTempDbPath();
+        try
+        {
+            using (SqliteSfftAnalysisStore first = new(
+                       dbFilePath,
+                       "T_SFFTAnalysis",
+                       SqliteConflictMode.Error,
+                       binCount: 8,
+                       deleteCurrent: false))
+            {
+                first.Initialize();
+                first.Complete();
+            }
+
+            using SqliteSfftAnalysisStore second = new(
+                dbFilePath,
+                "T_SFFTAnalysis",
+                SqliteConflictMode.Error,
+                binCount: 12,
+                deleteCurrent: false);
+
+            CliException exception = Assert.Throws<CliException>(() => second.Initialize());
+            Assert.Equal(CliErrorCode.SfftTableBinCountMismatch, exception.ErrorCode);
+        }
+        finally
+        {
+            DeleteIfExists(dbFilePath);
+        }
+    }
+
+    [Fact]
+    public void Initialize_ShouldRecreateTable_WhenDeleteCurrentIsEnabled()
+    {
+        string dbFilePath = CreateTempDbPath();
+        try
+        {
+            using (SqliteSfftAnalysisStore first = new(
+                       dbFilePath,
+                       "T_SFFTAnalysis",
+                       SqliteConflictMode.Error,
+                       binCount: 8,
+                       deleteCurrent: false))
+            {
+                first.Initialize();
+                first.Complete();
+            }
+
+            using (SqliteSfftAnalysisStore second = new(
+                       dbFilePath,
+                       "T_SFFTAnalysis",
+                       SqliteConflictMode.Error,
+                       binCount: 12,
+                       deleteCurrent: true))
+            {
+                second.Initialize();
+                second.Complete();
+            }
+
+            Assert.Equal(12, CountBinColumns(dbFilePath));
+        }
+        finally
+        {
+            DeleteIfExists(dbFilePath);
+        }
+    }
+
+    [Fact]
+    public void Write_ShouldUpsertAndKeepCreateAt()
+    {
+        string dbFilePath = CreateTempDbPath();
+        try
+        {
+            SfftAnalysisPoint firstPoint = new("Song", 0, 50, 10, CreateBins(4, -10));
+
+            using (SqliteSfftAnalysisStore store = new(
+                       dbFilePath,
+                       "T_SFFTAnalysis",
+                       SqliteConflictMode.Upsert,
+                       binCount: 4,
+                       deleteCurrent: false))
+            {
+                store.Initialize();
+                store.Write(firstPoint);
+                store.Complete();
+            }
+
+            (long createAtBefore, long modifiedAtBefore, double bin001Before) = ReadSingleRow(dbFilePath);
+            _ = SpinWait.SpinUntil(
+                () => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() > modifiedAtBefore,
+                TimeSpan.FromMilliseconds(200));
+
+            SfftAnalysisPoint updatedPoint = new("Song", 0, 50, 10, CreateBins(4, -3));
+            using (SqliteSfftAnalysisStore store = new(
+                       dbFilePath,
+                       "T_SFFTAnalysis",
+                       SqliteConflictMode.Upsert,
+                       binCount: 4,
+                       deleteCurrent: false))
+            {
+                store.Initialize();
+                store.Write(updatedPoint);
+                store.Complete();
+            }
+
+            (long createAtAfter, long modifiedAtAfter, double bin001After) = ReadSingleRow(dbFilePath);
+
+            Assert.Equal(createAtBefore, createAtAfter);
+            Assert.True(modifiedAtAfter >= modifiedAtBefore);
+            Assert.NotEqual(bin001Before, bin001After);
+            Assert.Equal(-3, bin001After, precision: 6);
+            Assert.Equal(1, ReadRowCount(dbFilePath));
+        }
+        finally
+        {
+            DeleteIfExists(dbFilePath);
+        }
+    }
+
+    [Fact]
+    public void Write_ShouldSkipDuplicate_WhenSkipDuplicateIsEnabled()
+    {
+        string dbFilePath = CreateTempDbPath();
+        try
+        {
+            SfftAnalysisPoint point = new("Song", 0, 50, 10, CreateBins(4, -10));
+
+            using (SqliteSfftAnalysisStore store = new(
+                       dbFilePath,
+                       "T_SFFTAnalysis",
+                       SqliteConflictMode.SkipDuplicate,
+                       binCount: 4,
+                       deleteCurrent: false))
+            {
+                store.Initialize();
+                store.Write(point);
+                store.Write(point);
+                store.Complete();
+            }
+
+            Assert.Equal(1, ReadRowCount(dbFilePath));
+        }
+        finally
+        {
+            DeleteIfExists(dbFilePath);
+        }
+    }
+
+    private static double[] CreateBins(int count, double value)
+    {
+        double[] bins = new double[count];
+        for (int i = 0; i < count; i++)
+        {
+            bins[i] = value;
+        }
+
+        return bins;
+    }
+
+    private static SqliteConnection OpenConnection(string dbFilePath)
+    {
+        SqliteConnectionStringBuilder builder = new()
+        {
+            DataSource = dbFilePath,
+            Pooling = false,
+        };
+
+        SqliteConnection connection = new(builder.ToString());
+        connection.Open();
+        return connection;
+    }
+
+    private static bool TableExists(string dbFilePath, string tableName)
+    {
+        using SqliteConnection connection = OpenConnection(dbFilePath);
+        using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(1) FROM sqlite_master WHERE type = 'table' AND name = $name;";
+        _ = command.Parameters.AddWithValue("$name", tableName);
+        object? scalar = command.ExecuteScalar();
+        return scalar is long count && count > 0;
+    }
+
+    private static int CountBinColumns(string dbFilePath)
+    {
+        using SqliteConnection connection = OpenConnection(dbFilePath);
+        using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = "PRAGMA table_info(\"T_SFFTAnalysis\");";
+
+        int count = 0;
+        using SqliteDataReader reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            string name = reader.GetString(1);
+            if (name.StartsWith("bin", StringComparison.OrdinalIgnoreCase))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static (long CreateAt, long ModifiedAt, double Bin001) ReadSingleRow(string dbFilePath)
+    {
+        using SqliteConnection connection = OpenConnection(dbFilePath);
+        using SqliteCommand command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT create_at, modified_at, bin001 FROM \"T_SFFTAnalysis\" WHERE name = 'Song' AND ch = 0 AND window = 50 AND ms = 10;";
+
+        using SqliteDataReader reader = command.ExecuteReader();
+        Assert.True(reader.Read());
+
+        long createAt = reader.GetInt64(0);
+        long modifiedAt = reader.GetInt64(1);
+        double bin001 = reader.GetDouble(2);
+        return (createAt, modifiedAt, bin001);
+    }
+
+    private static long ReadRowCount(string dbFilePath)
+    {
+        using SqliteConnection connection = OpenConnection(dbFilePath);
+        using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(1) FROM \"T_SFFTAnalysis\";";
+        object? scalar = command.ExecuteScalar();
+        return scalar is long count ? count : 0;
+    }
+
+    private static string CreateTempDbPath()
+    {
+        string directoryPath = Path.Combine(Path.GetTempPath(), $"sound-analyzer-sfft-db-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directoryPath);
+        return Path.Combine(directoryPath, "analysis.db");
+    }
+
+    private static void DeleteIfExists(string dbFilePath)
+    {
+        string? directoryPath = Path.GetDirectoryName(dbFilePath);
+        if (string.IsNullOrWhiteSpace(directoryPath) || !Directory.Exists(directoryPath))
+        {
+            return;
+        }
+
+        const int maxRetry = 5;
+        for (int i = 0; i < maxRetry; i++)
+        {
+            try
+            {
+                Directory.Delete(directoryPath, recursive: true);
+                return;
+            }
+            catch (IOException) when (i < maxRetry - 1)
+            {
+                _ = SpinWait.SpinUntil(static () => false, TimeSpan.FromMilliseconds(20));
+            }
+            catch (UnauthorizedAccessException) when (i < maxRetry - 1)
+            {
+                _ = SpinWait.SpinUntil(static () => false, TimeSpan.FromMilliseconds(20));
+            }
+        }
+    }
+}

--- a/SoundAnalyzer.Cli.Tests/Presentation/Cli/Arguments/CommandLineParserTests.cs
+++ b/SoundAnalyzer.Cli.Tests/Presentation/Cli/Arguments/CommandLineParserTests.cs
@@ -5,7 +5,7 @@ namespace SoundAnalyzer.Cli.Tests.Presentation.Cli.Arguments;
 
 public sealed class CommandLineParserTests
 {
-    private static readonly string[] BaseArgs =
+    private static readonly string[] BasePeakArgs =
     [
         "--window-size", "50ms",
         "--hop", "10ms",
@@ -14,12 +14,22 @@ public sealed class CommandLineParserTests
         "--mode", "peak-analysis",
     ];
 
+    private static readonly string[] BaseSfftArgs =
+    [
+        "--window-size", "50ms",
+        "--hop", "10ms",
+        "--input-dir", "C:/input",
+        "--db-file", "C:/tmp/analysis.db",
+        "--mode", "sfft-analysis",
+        "--bin-count", "12",
+    ];
+
     [Fact]
     public void Parse_ShouldFail_WhenUpsertAndSkipDuplicateAreSpecifiedTogether()
     {
         string[] args =
         [
-            .. BaseArgs,
+            .. BasePeakArgs,
             "--upsert",
             "--skip-duplicate",
         ];
@@ -35,7 +45,7 @@ public sealed class CommandLineParserTests
     {
         string[] args =
         [
-            .. BaseArgs,
+            .. BasePeakArgs,
             "--table-name-override", "T-PEAK_01",
         ];
 
@@ -51,7 +61,7 @@ public sealed class CommandLineParserTests
     {
         string[] args =
         [
-            .. BaseArgs,
+            .. BasePeakArgs,
             "--table-name-override", "T PEAK",
         ];
 
@@ -59,5 +69,112 @@ public sealed class CommandLineParserTests
 
         Assert.False(result.IsSuccess);
         Assert.Contains(result.Errors, error => error.Contains("Invalid table name", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Parse_ShouldRequireBinCount_WhenModeIsSfft()
+    {
+        string[] args =
+        [
+            "--window-size", "50ms",
+            "--hop", "10ms",
+            "--input-dir", "C:/input",
+            "--db-file", "C:/tmp/analysis.db",
+            "--mode", "sfft-analysis",
+        ];
+
+        CommandLineParseResult result = CommandLineParser.Parse(args);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            result.Errors,
+            error => string.Equals(
+                error,
+                ConsoleTexts.WithValue(ConsoleTexts.MissingOptionPrefix, ConsoleTexts.BinCountOption),
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Parse_ShouldRejectStems_WhenModeIsSfft()
+    {
+        string[] args =
+        [
+            .. BaseSfftArgs,
+            "--stems", "Piano",
+        ];
+
+        CommandLineParseResult result = CommandLineParser.Parse(args);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(ConsoleTexts.StemsNotSupportedForSfftText, result.Errors, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_ShouldRejectBinCount_WhenModeIsPeak()
+    {
+        string[] args =
+        [
+            .. BasePeakArgs,
+            "--bin-count", "12",
+        ];
+
+        CommandLineParseResult result = CommandLineParser.Parse(args);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(ConsoleTexts.BinCountOnlyForSfftText, result.Errors, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_ShouldRejectRecursive_WhenModeIsPeak()
+    {
+        string[] args =
+        [
+            .. BasePeakArgs,
+            "--recursive",
+        ];
+
+        CommandLineParseResult result = CommandLineParser.Parse(args);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(ConsoleTexts.RecursiveOnlyForSfftText, result.Errors, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_ShouldRejectDeleteCurrent_WhenModeIsPeak()
+    {
+        string[] args =
+        [
+            .. BasePeakArgs,
+            "--delete-current",
+        ];
+
+        CommandLineParseResult result = CommandLineParser.Parse(args);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(ConsoleTexts.DeleteCurrentOnlyForSfftText, result.Errors, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_ShouldUseSfftDefaultTableName_WhenModeIsSfft()
+    {
+        CommandLineParseResult result = CommandLineParser.Parse(BaseSfftArgs);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Arguments);
+        Assert.Equal(ConsoleTexts.DefaultSfftTableName, result.Arguments.TableName, StringComparer.Ordinal);
+        Assert.Equal(ConsoleTexts.SfftAnalysisMode, result.Arguments.Mode, StringComparer.Ordinal);
+        Assert.Equal(12, result.Arguments.BinCount);
+    }
+
+    [Fact]
+    public void Parse_ShouldUsePeakDefaultTableName_WhenModeIsPeak()
+    {
+        CommandLineParseResult result = CommandLineParser.Parse(BasePeakArgs);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Arguments);
+        Assert.Equal(ConsoleTexts.DefaultPeakTableName, result.Arguments.TableName, StringComparer.Ordinal);
+        Assert.Equal(ConsoleTexts.PeakAnalysisMode, result.Arguments.Mode, StringComparer.Ordinal);
+        Assert.Null(result.Arguments.BinCount);
     }
 }

--- a/SoundAnalyzer.Cli.Tests/SoundAnalyzer.Cli.Tests.csproj
+++ b/SoundAnalyzer.Cli.Tests/SoundAnalyzer.Cli.Tests.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\SoundAnalyzer.Cli\SoundAnalyzer.Cli.csproj" />
     <ProjectReference Include="..\PeakAnalyzer.Core\PeakAnalyzer.Core.csproj" />
+    <ProjectReference Include="..\SFFTAnalyzer.Core\SFFTAnalyzer.Core.csproj" />
     <ProjectReference Include="..\AudioProcessor\AudioProcessor.csproj" />
   </ItemGroup>
 

--- a/SoundAnalyzer.Cli/Infrastructure/Execution/BatchExecutionSupport.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Execution/BatchExecutionSupport.cs
@@ -1,0 +1,44 @@
+using SoundAnalyzer.Cli.Infrastructure.Sqlite;
+using SoundAnalyzer.Cli.Presentation.Cli.Arguments;
+
+namespace SoundAnalyzer.Cli.Infrastructure.Execution;
+
+internal static class BatchExecutionSupport
+{
+    public static SqliteConflictMode ResolveConflictMode(CommandLineArguments arguments)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        if (arguments.Upsert)
+        {
+            return SqliteConflictMode.Upsert;
+        }
+
+        if (arguments.SkipDuplicate)
+        {
+            return SqliteConflictMode.SkipDuplicate;
+        }
+
+        return SqliteConflictMode.Error;
+    }
+
+    public static void EnsureDbDirectory(string dbFilePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dbFilePath);
+
+        string? directoryPath = Path.GetDirectoryName(dbFilePath);
+        if (string.IsNullOrWhiteSpace(directoryPath))
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(directoryPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            throw new CliException(CliErrorCode.DbDirectoryCreationFailed, directoryPath, ex);
+        }
+    }
+}

--- a/SoundAnalyzer.Cli/Infrastructure/Execution/CliErrorCode.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Execution/CliErrorCode.cs
@@ -5,4 +5,7 @@ internal enum CliErrorCode
     None = 0,
     InputDirectoryNotFound,
     DbDirectoryCreationFailed,
+    DuplicateSfftAnalysisName,
+    SfftTableBinCountMismatch,
+    UnsupportedMode,
 }

--- a/SoundAnalyzer.Cli/Infrastructure/Execution/SfftAnalysisBatchSummary.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Execution/SfftAnalysisBatchSummary.cs
@@ -1,0 +1,34 @@
+namespace SoundAnalyzer.Cli.Infrastructure.Execution;
+
+internal sealed class SfftAnalysisBatchSummary
+{
+    public SfftAnalysisBatchSummary(
+        int directoryCount,
+        int analyzedFileCount,
+        long writtenPointCount,
+        string tableName,
+        int binCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(directoryCount);
+        ArgumentOutOfRangeException.ThrowIfNegative(analyzedFileCount);
+        ArgumentOutOfRangeException.ThrowIfNegative(writtenPointCount);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(binCount);
+
+        DirectoryCount = directoryCount;
+        AnalyzedFileCount = analyzedFileCount;
+        WrittenPointCount = writtenPointCount;
+        TableName = tableName;
+        BinCount = binCount;
+    }
+
+    public int DirectoryCount { get; }
+
+    public int AnalyzedFileCount { get; }
+
+    public long WrittenPointCount { get; }
+
+    public string TableName { get; }
+
+    public int BinCount { get; }
+}

--- a/SoundAnalyzer.Cli/Infrastructure/FileSystem/ResolvedSfftAudioFiles.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/FileSystem/ResolvedSfftAudioFiles.cs
@@ -1,0 +1,17 @@
+namespace SoundAnalyzer.Cli.Infrastructure.FileSystem;
+
+internal sealed class ResolvedSfftAudioFiles
+{
+    public ResolvedSfftAudioFiles(IReadOnlyList<SfftAudioFile> files, int directoryCount)
+    {
+        ArgumentNullException.ThrowIfNull(files);
+        ArgumentOutOfRangeException.ThrowIfNegative(directoryCount);
+
+        Files = files;
+        DirectoryCount = directoryCount;
+    }
+
+    public IReadOnlyList<SfftAudioFile> Files { get; }
+
+    public int DirectoryCount { get; }
+}

--- a/SoundAnalyzer.Cli/Infrastructure/FileSystem/SfftAudioFile.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/FileSystem/SfftAudioFile.cs
@@ -1,0 +1,17 @@
+namespace SoundAnalyzer.Cli.Infrastructure.FileSystem;
+
+internal sealed class SfftAudioFile
+{
+    public SfftAudioFile(string name, string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        Name = name;
+        FilePath = filePath;
+    }
+
+    public string Name { get; }
+
+    public string FilePath { get; }
+}

--- a/SoundAnalyzer.Cli/Infrastructure/FileSystem/SfftAudioFileResolver.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/FileSystem/SfftAudioFileResolver.cs
@@ -1,0 +1,163 @@
+using SoundAnalyzer.Cli.Infrastructure.Execution;
+
+namespace SoundAnalyzer.Cli.Infrastructure.FileSystem;
+
+internal static class SfftAudioFileResolver
+{
+    private static readonly HashSet<string> SupportedExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".wav",
+        ".flac",
+        ".m4a",
+        ".caf",
+    };
+
+    public static ResolvedSfftAudioFiles Resolve(string inputDirectoryPath, bool recursive)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(inputDirectoryPath);
+
+        SearchOption searchOption = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
+        string[] paths = Directory
+            .EnumerateFiles(inputDirectoryPath, "*", searchOption)
+            .Where(IsSupportedAudioFile)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        List<SfftAudioFile> files = SelectPreferredCandidates(paths, inputDirectoryPath);
+        EnsureNoDuplicateNames(files);
+
+        int directoryCount = recursive
+            ? Directory.GetDirectories(inputDirectoryPath, "*", SearchOption.AllDirectories).Length + 1
+            : 1;
+
+        return new ResolvedSfftAudioFiles(files, directoryCount);
+    }
+
+    private static List<SfftAudioFile> SelectPreferredCandidates(string[] paths, string inputDirectoryPath)
+    {
+        ArgumentNullException.ThrowIfNull(paths);
+        ArgumentException.ThrowIfNullOrWhiteSpace(inputDirectoryPath);
+
+        Dictionary<string, List<FileCandidate>> grouped = new(StringComparer.OrdinalIgnoreCase);
+        List<string> orderedKeys = new();
+
+        for (int i = 0; i < paths.Length; i++)
+        {
+            string path = paths[i];
+            string name = Path.GetFileNameWithoutExtension(path);
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            string directoryPath = Path.GetDirectoryName(path) ?? inputDirectoryPath;
+            string key = string.Create(
+                System.Globalization.CultureInfo.InvariantCulture,
+                $"{directoryPath}\n{name}");
+
+            if (!grouped.TryGetValue(key, out List<FileCandidate>? candidates))
+            {
+                candidates = new List<FileCandidate>();
+                grouped[key] = candidates;
+                orderedKeys.Add(key);
+            }
+
+            candidates.Add(new FileCandidate(path, name, i));
+        }
+
+        List<SfftAudioFile> resolved = new(orderedKeys.Count);
+        for (int i = 0; i < orderedKeys.Count; i++)
+        {
+            string key = orderedKeys[i];
+            FileCandidate selected = SelectPreferred(grouped[key]);
+            resolved.Add(new SfftAudioFile(selected.Name, selected.Path));
+        }
+
+        return resolved;
+    }
+
+    private static void EnsureNoDuplicateNames(List<SfftAudioFile> files)
+    {
+        ArgumentNullException.ThrowIfNull(files);
+
+        HashSet<string> names = new(StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i < files.Count; i++)
+        {
+            SfftAudioFile file = files[i];
+            if (!names.Add(file.Name))
+            {
+                throw new CliException(CliErrorCode.DuplicateSfftAnalysisName, file.Name);
+            }
+        }
+    }
+
+    private static FileCandidate SelectPreferred(IReadOnlyList<FileCandidate> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (options.Count == 0)
+        {
+            throw new ArgumentException("At least one file candidate is required.", nameof(options));
+        }
+
+        FileCandidate? best = null;
+        int bestPriority = int.MaxValue;
+        int bestOrder = int.MaxValue;
+
+        for (int i = 0; i < options.Count; i++)
+        {
+            FileCandidate candidate = options[i];
+            int priority = GetExtensionPriority(candidate.Path);
+            if (best is null || priority < bestPriority || (priority == bestPriority && candidate.DiscoveryOrder < bestOrder))
+            {
+                best = candidate;
+                bestPriority = priority;
+                bestOrder = candidate.DiscoveryOrder;
+            }
+        }
+
+        return best!;
+    }
+
+    private static int GetExtensionPriority(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        string extension = Path.GetExtension(path).TrimStart('.').ToLowerInvariant();
+        return extension switch
+        {
+            "wav" => 0,
+            "flac" => 1,
+            "m4a" => 2,
+            "caf" => 2,
+            _ => 3,
+        };
+    }
+
+    private static bool IsSupportedAudioFile(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        string extension = Path.GetExtension(path);
+        return SupportedExtensions.Contains(extension);
+    }
+
+    private sealed class FileCandidate
+    {
+        public FileCandidate(string path, string name, int discoveryOrder)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(path);
+            ArgumentException.ThrowIfNullOrWhiteSpace(name);
+            ArgumentOutOfRangeException.ThrowIfNegative(discoveryOrder);
+
+            Path = path;
+            Name = name;
+            DiscoveryOrder = discoveryOrder;
+        }
+
+        public string Path { get; }
+
+        public string Name { get; }
+
+        public int DiscoveryOrder { get; }
+    }
+}

--- a/SoundAnalyzer.Cli/Infrastructure/Sqlite/SqliteSfftAnalysisStore.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Sqlite/SqliteSfftAnalysisStore.cs
@@ -1,0 +1,398 @@
+using System.Globalization;
+using Microsoft.Data.Sqlite;
+using SFFTAnalyzer.Core.Application.Ports;
+using SFFTAnalyzer.Core.Domain.Models;
+using SoundAnalyzer.Cli.Infrastructure.Execution;
+
+namespace SoundAnalyzer.Cli.Infrastructure.Sqlite;
+
+#pragma warning disable CA2100
+internal sealed class SqliteSfftAnalysisStore : ISfftAnalysisPointWriter, IDisposable
+{
+    private readonly string dbFilePath;
+    private readonly string tableName;
+    private readonly SqliteConflictMode conflictMode;
+    private readonly int binCount;
+    private readonly bool deleteCurrent;
+
+    private SqliteConnection? connection;
+    private SqliteTransaction? transaction;
+    private SqliteCommand? insertCommand;
+    private bool completed;
+
+    public SqliteSfftAnalysisStore(
+        string dbFilePath,
+        string tableName,
+        SqliteConflictMode conflictMode,
+        int binCount,
+        bool deleteCurrent)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dbFilePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(binCount);
+
+        this.dbFilePath = dbFilePath;
+        this.tableName = tableName;
+        this.conflictMode = conflictMode;
+        this.binCount = binCount;
+        this.deleteCurrent = deleteCurrent;
+    }
+
+    public void Initialize()
+    {
+        if (connection is not null)
+        {
+            return;
+        }
+
+        connection = new SqliteConnection(BuildConnectionString(dbFilePath));
+        connection.Open();
+
+        transaction = connection.BeginTransaction();
+
+        if (deleteCurrent)
+        {
+            DropTableIfExists(connection, transaction, tableName);
+        }
+        else if (TableExists(connection, transaction, tableName))
+        {
+            int existingBinCount = CountExistingBinColumns(connection, transaction, tableName);
+            if (existingBinCount != binCount)
+            {
+                string detail = string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"table={tableName}, expected={binCount}, actual={existingBinCount}");
+                throw new CliException(CliErrorCode.SfftTableBinCountMismatch, detail);
+            }
+        }
+
+        CreateTableIfNeeded(connection, transaction, tableName, binCount);
+        CreateIndexesIfNeeded(connection, transaction, tableName);
+
+        insertCommand = BuildInsertCommand(connection, transaction, tableName, conflictMode, binCount);
+    }
+
+    public void Write(SfftAnalysisPoint point)
+    {
+        ArgumentNullException.ThrowIfNull(point);
+
+        if (point.Bins.Count != binCount)
+        {
+            throw new ArgumentException("Point bin-count does not match configured bin-count.", nameof(point));
+        }
+
+        SqliteCommand command = insertCommand
+            ?? throw new InvalidOperationException("SqliteSfftAnalysisStore is not initialized.");
+
+        long nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        command.Parameters["$name"].Value = point.Name;
+        command.Parameters["$ch"].Value = point.Channel;
+        command.Parameters["$window"].Value = point.WindowMs;
+        command.Parameters["$ms"].Value = point.Ms;
+
+        for (int i = 0; i < binCount; i++)
+        {
+            string parameterName = GetBinParameterName(i + 1);
+            command.Parameters[parameterName].Value = point.Bins[i];
+        }
+
+        command.Parameters["$createAt"].Value = nowMs;
+        command.Parameters["$modifiedAt"].Value = nowMs;
+
+        _ = command.ExecuteNonQuery();
+    }
+
+    public void Complete()
+    {
+        SqliteTransaction? currentTransaction = transaction;
+        if (currentTransaction is null)
+        {
+            return;
+        }
+
+        currentTransaction.Commit();
+        completed = true;
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (!completed)
+            {
+                transaction?.Rollback();
+            }
+        }
+        finally
+        {
+            insertCommand?.Dispose();
+            transaction?.Dispose();
+            connection?.Dispose();
+        }
+    }
+
+    private static void DropTableIfExists(SqliteConnection connection, SqliteTransaction transaction, string tableName)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(transaction);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
+
+        using SqliteCommand command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = string.Create(
+            CultureInfo.InvariantCulture,
+            $"DROP TABLE IF EXISTS {QuoteIdentifier(tableName)};");
+        _ = command.ExecuteNonQuery();
+    }
+
+    private static bool TableExists(SqliteConnection connection, SqliteTransaction transaction, string tableName)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(transaction);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
+
+        using SqliteCommand command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText =
+            "SELECT COUNT(1) FROM sqlite_master WHERE type = 'table' AND name = $name;";
+        _ = command.Parameters.AddWithValue("$name", tableName);
+
+        object? scalar = command.ExecuteScalar();
+        return scalar is long count && count > 0;
+    }
+
+    private static int CountExistingBinColumns(SqliteConnection connection, SqliteTransaction transaction, string tableName)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(transaction);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
+
+        using SqliteCommand command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = string.Create(
+            CultureInfo.InvariantCulture,
+            $"PRAGMA table_info({QuoteIdentifier(tableName)});");
+
+        int count = 0;
+        using SqliteDataReader reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            string columnName = reader.GetString(1);
+            if (columnName.StartsWith("bin", StringComparison.OrdinalIgnoreCase))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static void CreateTableIfNeeded(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        string tableName,
+        int binCount)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(transaction);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(binCount);
+
+        string quotedTable = QuoteIdentifier(tableName);
+
+        string[] binColumns = new string[binCount];
+        for (int i = 0; i < binCount; i++)
+        {
+            string columnName = QuoteIdentifier(GetBinColumnName(i + 1));
+            binColumns[i] = string.Create(CultureInfo.InvariantCulture, $"{columnName} REAL NOT NULL");
+        }
+
+        string joinedBinColumns = string.Join(",\n  ", binColumns);
+
+        string sql = string.Create(
+            CultureInfo.InvariantCulture,
+            $"""
+            CREATE TABLE IF NOT EXISTS {quotedTable} (
+              "idx" INTEGER PRIMARY KEY AUTOINCREMENT,
+              "name" TEXT NOT NULL,
+              "ch" INTEGER NOT NULL,
+              "window" INTEGER NOT NULL,
+              "ms" INTEGER NOT NULL,
+              {joinedBinColumns},
+              "create_at" INTEGER NOT NULL,
+              "modified_at" INTEGER NOT NULL,
+              UNIQUE("name", "ch", "window", "ms")
+            );
+            """);
+
+        using SqliteCommand command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = sql;
+        _ = command.ExecuteNonQuery();
+    }
+
+    private static void CreateIndexesIfNeeded(SqliteConnection connection, SqliteTransaction transaction, string tableName)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(transaction);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
+
+        string quotedTable = QuoteIdentifier(tableName);
+        string safePrefix = tableName.Replace("-", "_", StringComparison.Ordinal);
+
+        string[] statements =
+        {
+            BuildIndexStatement(safePrefix, "name", quotedTable, "name"),
+            BuildIndexStatement(safePrefix, "name_ch", quotedTable, "name", "ch"),
+            BuildIndexStatement(safePrefix, "name_ms", quotedTable, "name", "ms"),
+            BuildIndexStatement(safePrefix, "name_ch_ms", quotedTable, "name", "ch", "ms"),
+        };
+
+        for (int i = 0; i < statements.Length; i++)
+        {
+            using SqliteCommand command = connection.CreateCommand();
+            command.Transaction = transaction;
+            command.CommandText = statements[i];
+            _ = command.ExecuteNonQuery();
+        }
+    }
+
+    private static string BuildIndexStatement(string prefix, string suffix, string quotedTable, params string[] columns)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(prefix);
+        ArgumentException.ThrowIfNullOrWhiteSpace(suffix);
+        ArgumentException.ThrowIfNullOrWhiteSpace(quotedTable);
+        ArgumentNullException.ThrowIfNull(columns);
+
+        string indexName = QuoteIdentifier(string.Create(CultureInfo.InvariantCulture, $"IX_{prefix}_{suffix}"));
+        string joinedColumns = string.Join(", ", columns.Select(column => QuoteIdentifier(column)));
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"CREATE INDEX IF NOT EXISTS {indexName} ON {quotedTable} ({joinedColumns});");
+    }
+
+    private static SqliteCommand BuildInsertCommand(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        string tableName,
+        SqliteConflictMode conflictMode,
+        int binCount)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(transaction);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(binCount);
+
+        string quotedTable = QuoteIdentifier(tableName);
+
+        List<string> columns =
+        [
+            QuoteIdentifier("name"),
+            QuoteIdentifier("ch"),
+            QuoteIdentifier("window"),
+            QuoteIdentifier("ms"),
+        ];
+
+        List<string> values = ["$name", "$ch", "$window", "$ms"];
+
+        for (int i = 0; i < binCount; i++)
+        {
+            int index = i + 1;
+            columns.Add(QuoteIdentifier(GetBinColumnName(index)));
+            values.Add(GetBinParameterName(index));
+        }
+
+        columns.Add(QuoteIdentifier("create_at"));
+        columns.Add(QuoteIdentifier("modified_at"));
+        values.Add("$createAt");
+        values.Add("$modifiedAt");
+
+        string insertSql = string.Create(
+            CultureInfo.InvariantCulture,
+            $"INSERT INTO {quotedTable} ({string.Join(", ", columns)}) VALUES ({string.Join(", ", values)})");
+
+        string sql = conflictMode switch
+        {
+            SqliteConflictMode.Upsert => string.Concat(
+                insertSql,
+                " ON CONFLICT(\"name\", \"ch\", \"window\", \"ms\") DO UPDATE SET ",
+                BuildUpsertSetClause(binCount),
+                ";"),
+            SqliteConflictMode.SkipDuplicate => string.Concat(
+                insertSql,
+                " ON CONFLICT(\"name\", \"ch\", \"window\", \"ms\") DO NOTHING;"),
+            _ => string.Concat(insertSql, ";"),
+        };
+
+        SqliteCommand command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = sql;
+
+        _ = command.Parameters.Add("$name", SqliteType.Text);
+        _ = command.Parameters.Add("$ch", SqliteType.Integer);
+        _ = command.Parameters.Add("$window", SqliteType.Integer);
+        _ = command.Parameters.Add("$ms", SqliteType.Integer);
+
+        for (int i = 0; i < binCount; i++)
+        {
+            _ = command.Parameters.Add(GetBinParameterName(i + 1), SqliteType.Real);
+        }
+
+        _ = command.Parameters.Add("$createAt", SqliteType.Integer);
+        _ = command.Parameters.Add("$modifiedAt", SqliteType.Integer);
+        command.Prepare();
+
+        return command;
+    }
+
+    private static string BuildUpsertSetClause(int binCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(binCount);
+
+        List<string> assignments = new(binCount + 1);
+        for (int i = 0; i < binCount; i++)
+        {
+            string quotedColumn = QuoteIdentifier(GetBinColumnName(i + 1));
+            assignments.Add(string.Create(CultureInfo.InvariantCulture, $"{quotedColumn} = excluded.{quotedColumn}"));
+        }
+
+        assignments.Add("\"modified_at\" = excluded.\"modified_at\"");
+        return string.Join(", ", assignments);
+    }
+
+    private static string GetBinColumnName(int oneBasedIndex)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(oneBasedIndex);
+        return string.Create(CultureInfo.InvariantCulture, $"bin{oneBasedIndex:D3}");
+    }
+
+    private static string GetBinParameterName(int oneBasedIndex)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(oneBasedIndex);
+        return string.Create(CultureInfo.InvariantCulture, $"$bin{oneBasedIndex:D3}");
+    }
+
+    private static string BuildConnectionString(string dbFilePath)
+    {
+        SqliteConnectionStringBuilder builder = new()
+        {
+            DataSource = dbFilePath,
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            ForeignKeys = false,
+            Pooling = false,
+        };
+
+        return builder.ToString();
+    }
+
+    private static string QuoteIdentifier(string identifier)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(identifier);
+
+        string escaped = identifier.Replace("\"", "\"\"", StringComparison.Ordinal);
+        return string.Create(CultureInfo.InvariantCulture, $"\"{escaped}\"");
+    }
+}
+#pragma warning restore CA2100

--- a/SoundAnalyzer.Cli/Presentation/Cli/Arguments/CommandLineArguments.cs
+++ b/SoundAnalyzer.Cli/Presentation/Cli/Arguments/CommandLineArguments.cs
@@ -13,6 +13,9 @@ internal sealed class CommandLineArguments
         bool upsert,
         bool skipDuplicate,
         double minLimitDb,
+        int? binCount,
+        bool deleteCurrent,
+        bool recursive,
         string? ffmpegPath)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(windowSizeMs);
@@ -27,6 +30,11 @@ internal sealed class CommandLineArguments
             throw new ArgumentOutOfRangeException(nameof(minLimitDb));
         }
 
+        if (binCount.HasValue)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(binCount.Value);
+        }
+
         WindowSizeMs = windowSizeMs;
         HopMs = hopMs;
         InputDirectoryPath = inputDirectoryPath;
@@ -37,6 +45,9 @@ internal sealed class CommandLineArguments
         Upsert = upsert;
         SkipDuplicate = skipDuplicate;
         MinLimitDb = minLimitDb;
+        BinCount = binCount;
+        DeleteCurrent = deleteCurrent;
+        Recursive = recursive;
         FfmpegPath = ffmpegPath;
     }
 
@@ -59,6 +70,12 @@ internal sealed class CommandLineArguments
     public bool SkipDuplicate { get; }
 
     public double MinLimitDb { get; }
+
+    public int? BinCount { get; }
+
+    public bool DeleteCurrent { get; }
+
+    public bool Recursive { get; }
 
     public string? FfmpegPath { get; }
 }

--- a/SoundAnalyzer.Cli/Presentation/Cli/Errors/CliErrorMapper.cs
+++ b/SoundAnalyzer.Cli/Presentation/Cli/Errors/CliErrorMapper.cs
@@ -1,6 +1,7 @@
 using AudioProcessor.Application.Errors;
 using Microsoft.Data.Sqlite;
 using PeakAnalyzer.Core.Application.Errors;
+using SFFTAnalyzer.Core.Application.Errors;
 using SoundAnalyzer.Cli.Infrastructure.Execution;
 using SoundAnalyzer.Cli.Presentation.Cli.Texts;
 
@@ -16,6 +17,9 @@ internal static class CliErrorMapper
         {
             CliErrorCode.InputDirectoryNotFound => ConsoleTexts.WithValue(ConsoleTexts.InputDirectoryNotFoundPrefix, exception.Detail),
             CliErrorCode.DbDirectoryCreationFailed => ConsoleTexts.WithValue(ConsoleTexts.FailedToCreateDbDirectoryPrefix, exception.Detail),
+            CliErrorCode.DuplicateSfftAnalysisName => ConsoleTexts.WithValue(ConsoleTexts.DuplicateSfftAnalysisNamePrefix, exception.Detail),
+            CliErrorCode.SfftTableBinCountMismatch => ConsoleTexts.WithValue(ConsoleTexts.SfftBinCountMismatchPrefix, exception.Detail),
+            CliErrorCode.UnsupportedMode => ConsoleTexts.WithValue(ConsoleTexts.InvalidModePrefix, exception.Detail),
             _ => exception.Detail,
         };
     }
@@ -30,6 +34,21 @@ internal static class CliErrorMapper
             PeakAnalysisErrorCode.InvalidWindowSize => ConsoleTexts.WithValue(ConsoleTexts.PeakInvalidWindowPrefix, exception.Detail),
             PeakAnalysisErrorCode.InvalidHop => ConsoleTexts.WithValue(ConsoleTexts.PeakInvalidHopPrefix, exception.Detail),
             PeakAnalysisErrorCode.InvalidMinLimitDb => ConsoleTexts.WithValue(ConsoleTexts.PeakInvalidMinLimitPrefix, exception.Detail),
+            _ => exception.Detail,
+        };
+    }
+
+    public static string ToMessage(SfftAnalysisException exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        return exception.ErrorCode switch
+        {
+            SfftAnalysisErrorCode.InputFileNotFound => ConsoleTexts.WithValue(ConsoleTexts.SfftInputFileNotFoundPrefix, exception.Detail),
+            SfftAnalysisErrorCode.InvalidWindowSize => ConsoleTexts.WithValue(ConsoleTexts.SfftInvalidWindowPrefix, exception.Detail),
+            SfftAnalysisErrorCode.InvalidHop => ConsoleTexts.WithValue(ConsoleTexts.SfftInvalidHopPrefix, exception.Detail),
+            SfftAnalysisErrorCode.InvalidBinCount => ConsoleTexts.WithValue(ConsoleTexts.SfftInvalidBinCountPrefix, exception.Detail),
+            SfftAnalysisErrorCode.InvalidMinLimitDb => ConsoleTexts.WithValue(ConsoleTexts.SfftInvalidMinLimitPrefix, exception.Detail),
             _ => exception.Detail,
         };
     }

--- a/SoundAnalyzer.Cli/Presentation/Cli/Texts/ConsoleTexts.cs
+++ b/SoundAnalyzer.Cli/Presentation/Cli/Texts/ConsoleTexts.cs
@@ -14,36 +14,46 @@ internal static class ConsoleTexts
     public const string UpsertOption = "--upsert";
     public const string SkipDuplicateOption = "--skip-duplicate";
     public const string MinLimitDbOption = "--min-limit-db";
+    public const string BinCountOption = "--bin-count";
+    public const string DeleteCurrentOption = "--delete-current";
+    public const string RecursiveOption = "--recursive";
     public const string FfmpegPathOption = "--ffmpeg-path";
     public const string HelpOption = "--help";
     public const string ShortHelpOption = "-h";
 
     public const string PeakAnalysisMode = "peak-analysis";
-    public const string DefaultTableName = "T_PeakAnalysis";
+    public const string SfftAnalysisMode = "sfft-analysis";
+
+    public const string DefaultPeakTableName = "T_PeakAnalysis";
+    public const string DefaultSfftTableName = "T_SFFTAnalysis";
 
     public const string HelpText =
 """
 Usage:
-  SoundAnalyzer.Cli.exe --window-size <time> --hop <time> --input-dir <path> --db-file <path> --mode peak-analysis [options]
+  SoundAnalyzer.Cli.exe --window-size <time> --hop <time> --input-dir <path> --db-file <path> --mode <peak-analysis|sfft-analysis> [options]
 
 Required options:
   --window-size <time>      Analysis window size (ms/s/m), integral milliseconds only
   --hop <time>              Hop size (ms/s/m), integral milliseconds only
-  --input-dir <path>        Input root directory (only first-level subdirectories are scanned)
+  --input-dir <path>        Input root directory
   --db-file <path>          SQLite db file path
-  --mode <value>            Only peak-analysis is supported
+  --mode <value>            peak-analysis or sfft-analysis
 
 Optional:
-  --stems <csv>             Stem names to analyze (case-insensitive). Omit to analyze all stems.
-  --table-name-override <n> Override table name (default: T_PeakAnalysis)
-  --upsert                  Upsert by unique key (name, stem, window, ms)
-  --skip-duplicate          Skip duplicates by unique key (name, stem, window, ms)
-  --min-limit-db <dB>       Clamp lower dB bound for all windows (default: -120.0)
+  --stems <csv>             Peak mode only. Stem names to analyze (case-insensitive)
+  --table-name-override <n> Override table name (default: peak=T_PeakAnalysis, sfft=T_SFFTAnalysis)
+  --upsert                  Upsert by unique key
+  --skip-duplicate          Skip duplicates by unique key
+  --min-limit-db <dB>       Clamp lower dB bound for all windows/bins (default: -120.0)
+  --bin-count <n>           SFFT mode only. Number of output bands (required in sfft-analysis)
+  --delete-current          SFFT mode only. Drop current table before processing
+  --recursive               SFFT mode only. Scan files recursively from input-dir
   --ffmpeg-path <path>      ffmpeg executable path or directory containing ffmpeg/ffprobe
   --help, -h                Show help
 
-Example:
-  SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --stems Piano,Drums,Vocals --mode peak-analysis --table-name-override T_PEAK --upsert
+Examples:
+  SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --mode peak-analysis --stems Piano,Drums --table-name-override T_PEAK --upsert
+  SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --mode sfft-analysis --bin-count 12 --table-name-override T_SFFT --upsert --recursive
 """;
 
     public const string MissingOptionPrefix = "Missing required option: ";
@@ -51,26 +61,39 @@ Example:
     public const string UnknownOptionPrefix = "Unknown option: ";
     public const string InvalidTimePrefix = "Invalid time value (ms/s/m, integral ms required): ";
     public const string InvalidNumberPrefix = "Invalid numeric value: ";
+    public const string InvalidIntegerPrefix = "Invalid integer value: ";
     public const string InvalidModePrefix = "Unsupported mode: ";
     public const string InvalidTableNamePrefix = "Invalid table name: ";
     public const string InvalidStemsText = "--stems must contain at least one stem name when specified.";
     public const string UpsertSkipConflictText = "--upsert and --skip-duplicate cannot be specified together.";
+    public const string BinCountOnlyForSfftText = "--bin-count can only be used with --mode sfft-analysis.";
+    public const string DeleteCurrentOnlyForSfftText = "--delete-current can only be used with --mode sfft-analysis.";
+    public const string RecursiveOnlyForSfftText = "--recursive can only be used with --mode sfft-analysis.";
+    public const string StemsNotSupportedForSfftText = "--stems is not supported with --mode sfft-analysis.";
 
     public const string InputDirectoryNotFoundPrefix = "Input directory does not exist: ";
     public const string FailedToCreateDbDirectoryPrefix = "Failed to create db directory: ";
+    public const string DuplicateSfftAnalysisNamePrefix = "Duplicate analysis name in input set (case-insensitive): ";
+    public const string SfftBinCountMismatchPrefix = "Existing SFFT table bin-count mismatch: ";
     public const string DatabaseOperationFailedPrefix = "Database operation failed: ";
     public const string OperationCanceledText = "Operation was canceled.";
 
     public const string FfmpegNotFoundPrefix = "ffmpeg was not found or not executable: ";
     public const string FfprobeNotFoundPrefix = "ffprobe was not found or not executable: ";
     public const string ProbeFailedPrefix = "Failed to probe audio stream: ";
-    public const string AnalyzeFailedPrefix = "Failed to analyze peak windows: ";
+    public const string AnalyzeFailedPrefix = "Failed to analyze windows: ";
     public const string UnsupportedSampleFormatPrefix = "Unsupported input sample format: ";
 
     public const string PeakInputFileNotFoundPrefix = "Input file does not exist: ";
     public const string PeakInvalidWindowPrefix = "Invalid window-size: ";
     public const string PeakInvalidHopPrefix = "Invalid hop: ";
     public const string PeakInvalidMinLimitPrefix = "Invalid min-limit-db: ";
+
+    public const string SfftInputFileNotFoundPrefix = "Input file does not exist: ";
+    public const string SfftInvalidWindowPrefix = "Invalid window-size: ";
+    public const string SfftInvalidHopPrefix = "Invalid hop: ";
+    public const string SfftInvalidBinCountPrefix = "Invalid bin-count: ";
+    public const string SfftInvalidMinLimitPrefix = "Invalid min-limit-db: ";
 
     public static string WithValue(string prefix, string value)
     {

--- a/SoundAnalyzer.Cli/README.md
+++ b/SoundAnalyzer.Cli/README.md
@@ -1,13 +1,13 @@
 # SoundAnalyzer.Cli
 
 ## 役割
-`SoundAnalyzer.Cli` は、ディレクトリ配下の STEM 音源を一括解析し、ピーク窓結果を SQLite へ保存する CLI です。  
-解析ロジックは `PeakAnalyzer.Core`、音声I/Oは `AudioProcessor` を利用します。
+`SoundAnalyzer.Cli` は、ディレクトリ配下の音声ファイルを一括解析し、結果を SQLite へ保存する CLI です。  
+`peak-analysis` は `PeakAnalyzer.Core`、`sfft-analysis` は `SFFTAnalyzer.Core` を利用します。
 
 ## 実行形式
 
 ```powershell
-SoundAnalyzer.Cli.exe --window-size <time> --hop <time> --input-dir <path> --db-file <path> --mode peak-analysis [options]
+SoundAnalyzer.Cli.exe --window-size <time> --hop <time> --input-dir <path> --db-file <path> --mode <peak-analysis|sfft-analysis> [options]
 ```
 
 ## オプション
@@ -16,11 +16,10 @@ SoundAnalyzer.Cli.exe --window-size <time> --hop <time> --input-dir <path> --db-
 |---|---|---|
 | `--window-size <time>` | 必須 | 窓サイズ（`ms/s/m`、整数ms化可能であること） |
 | `--hop <time>` | 必須 | hop（`ms/s/m`、整数ms化可能であること） |
-| `--input-dir <path>` | 必須 | 入力ルート（1階層サブディレクトリのみ走査） |
+| `--input-dir <path>` | 必須 | 入力ルート |
 | `--db-file <path>` | 必須 | SQLite ファイル |
-| `--mode peak-analysis` | 必須 | モード（現状 `peak-analysis` 固定） |
-| `--stems <csv>` | 任意 | 解析対象 stem 名（大小無視） |
-| `--table-name-override <name>` | 任意 | 既定 `T_PeakAnalysis` |
+| `--mode <value>` | 必須 | `peak-analysis` または `sfft-analysis` |
+| `--table-name-override <name>` | 任意 | テーブル名上書き |
 | `--upsert` | 任意 | 競合時更新 |
 | `--skip-duplicate` | 任意 | 競合時スキップ |
 | `--min-limit-db <dB>` | 任意 | 下限クランプ（既定 `-120.0`） |
@@ -29,13 +28,43 @@ SoundAnalyzer.Cli.exe --window-size <time> --hop <time> --input-dir <path> --db-
 
 `--upsert` と `--skip-duplicate` は同時指定不可です。
 
-## 対象ファイル解決
+### `peak-analysis` 専用
+
+| オプション | 説明 |
+|---|---|
+| `--stems <csv>` | 解析対象 stem 名（大小無視）。未指定時は全stem解析 |
+
+既定テーブル名: `T_PeakAnalysis`
+
+### `sfft-analysis` 専用
+
+| オプション | 説明 |
+|---|---|
+| `--bin-count <n>` | 出力band数（必須、`n >= 1`） |
+| `--delete-current` | 既存テーブルがあれば削除して再作成 |
+| `--recursive` | `input-dir` 配下を再帰走査 |
+
+既定テーブル名: `T_SFFTAnalysis`
+
+## 解析対象ファイルの解決
+
+### `peak-analysis`
 
 - 走査対象は `input-dir` 直下の1階層サブディレクトリ
 - stem 一致は大文字小文字無視
 - 同一 stem に複数拡張子がある場合の優先順は `wav -> flac -> m4a/caf -> others`
 
+### `sfft-analysis`
+
+- `--recursive` 未指定: `input-dir` 直下ファイルのみ
+- `--recursive` 指定: `input-dir` 配下を再帰走査
+- 対象拡張子は `wav/flac/m4a/caf`
+- 同一ディレクトリで同名別拡張子がある場合は `wav -> flac -> m4a/caf -> others` 優先で1件採用
+- 解析対象集合で `name`（拡張子なし）が大小無視で重複する場合は実行前エラー
+
 ## SQLite スキーマ
+
+### `peak-analysis`
 
 既定テーブル: `T_PeakAnalysis`
 
@@ -43,14 +72,26 @@ SoundAnalyzer.Cli.exe --window-size <time> --hop <time> --input-dir <path> --db-
 - 一意制約: `(name, stem, window, ms)`
 - インデックス: `(name)`, `(name, stem)`, `(name, ms)`, `(name, stem, ms)`
 
-競合時の挙動:
+### `sfft-analysis`
 
-- `--upsert`: `db`, `modified_at` を更新（`create_at` 維持）
-- `--skip-duplicate`: 何もしない
-- 未指定: エラー
+既定テーブル: `T_SFFTAnalysis`
+
+- 列: `idx`, `name`, `ch`, `window`, `ms`, `bin001..binNNN`, `create_at`, `modified_at`
+- 一意制約: `(name, ch, window, ms)`
+- インデックス: `(name)`, `(name, ch)`, `(name, ms)`, `(name, ch, ms)`
+
+`--delete-current` 未指定時は既存テーブルの `binNNN` 列数と `--bin-count` が一致する場合のみ続行します。
 
 ## 実行例
 
+### peak-analysis
+
 ```powershell
-SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --stems Piano,Drums,Vocals --mode peak-analysis --table-name-override T_PEAK --upsert
+SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --mode peak-analysis --stems Piano,Drums,Vocals --table-name-override T_PEAK --upsert
+```
+
+### sfft-analysis
+
+```powershell
+SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --mode sfft-analysis --bin-count 12 --table-name-override T_SFFT --upsert --recursive --delete-current
 ```

--- a/SoundAnalyzer.Cli/SoundAnalyzer.Cli.csproj
+++ b/SoundAnalyzer.Cli/SoundAnalyzer.Cli.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\PeakAnalyzer.Core\PeakAnalyzer.Core.csproj" />
+    <ProjectReference Include="..\SFFTAnalyzer.Core\SFFTAnalyzer.Core.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/build-logs/2026-02-24T161821-sfft-analysis-build.txt
+++ b/build-logs/2026-02-24T161821-sfft-analysis-build.txt
@@ -1,0 +1,20 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  SFFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SFFTAnalyzer.Core\bin\Debug\net10.0\SFFTAnalyzer.Core.dll
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+  SFFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SFFTAnalyzer.Core.Tests\bin\Debug\net10.0\SFFTAnalyzer.Core.Tests.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+
+ビルドに成功しました。
+    0 個の警告
+    0 エラー
+
+経過時間 00:00:01.41


### PR DESCRIPTION
## Background
Add `sfft-analysis` mode to `SoundAnalyzer.Cli` by introducing `SFFTAnalyzer.Core`, while preserving existing `peak-analysis` behavior.

Closes #5

## What changed
- Added new projects:
  - `SFFTAnalyzer.Core`
  - `SFFTAnalyzer.Core.Tests`
- Integrated new projects into `AudioProcessor.slnx`.
- Added SFFT domain/application/infrastructure contracts and use case:
  - `SfftAnalysisUseCase`, `SfftAnalysisRequest`, `SfftAnalysisPoint`, `SfftAnalysisSummary`
  - `ISfftAnalysisPointWriter`, `SfftAnalysisException`
  - Hann-windowed FFT analyzer with channel-separated output and banded dB values.
- Extended `SoundAnalyzer.Cli` to support mode dispatch:
  - `--mode peak-analysis | sfft-analysis`
  - SFFT-only options: `--bin-count`, `--delete-current`, `--recursive`
  - Validation rules for mode-specific options (`--stems` forbidden in SFFT mode, etc.).
- Added SFFT batch execution and persistence:
  - `SfftAnalysisBatchExecutor`, `SfftAnalysisBatchSummary`
  - `SfftAudioFileResolver` with extension priority and duplicate-name precheck
  - `SqliteSfftAnalysisStore` with dynamic `bin001..binNNN`, upsert/skip, and bin-count compatibility checks.
- Added/updated tests:
  - `SFFTAnalyzer.Core.Tests` for anchor behavior, padding, tail truncation, per-channel rows, bin count, and clamp.
  - `SoundAnalyzer.Cli.Tests` for parser mode rules, resolver behavior, and SFFT sqlite store behavior.
- Updated docs:
  - Root `README.md`
  - `SoundAnalyzer.Cli/README.md`
  - `SFFTAnalyzer.Core/README.md`
- Added reproducible build log:
  - `build-logs/2026-02-24T161821-sfft-analysis-build.txt`

## Public interface changes
- New CLI mode: `sfft-analysis`
- New CLI options: `--bin-count`, `--delete-current`, `--recursive`
- `SoundAnalyzer.Cli` argument contract now includes `BinCount`, `DeleteCurrent`, `Recursive`
- New SQLite default table for SFFT: `T_SFFTAnalysis`

## Compatibility impact
- Existing `peak-analysis` flows remain available.
- `--recursive`/`--delete-current` are intentionally rejected outside SFFT mode.
- `sfft-analysis` now requires `--bin-count`.

## Validation
Executed locally:

```powershell
dotnet build AudioProcessor.slnx -warnaserror
dotnet test AudioProcessor.slnx
dotnet run --project SoundAnalyzer.Cli -- --help
```

Result summary:
- Build: success, 0 warnings / 0 errors
- Tests: all passed
  - AudioProcessor.Tests: 12
  - AudioSplitter.Core.Tests: 7
  - PeakAnalyzer.Core.Tests: 5
  - SFFTAnalyzer.Core.Tests: 6
  - AudioSplitter.Cli.Tests: 14
  - SoundAnalyzer.Cli.Tests: 28

## Known constraints
- SFFT implementation uses an internal FFT routine (no new third-party dependency).
- SFFT schema compatibility check intentionally validates bin-column count only (per specification).
