### PR TITLE
refactor(sound-analyzer): normalize stft bin storage to avoid sqlite column-limit failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ AudioProcessor は、オーディオ解析・変換ツール群を提供する .
 - 窓STFT解析（チャネル別band dB）+ SQLite 保存: `SoundAnalyzer.Cli --mode stft-analysis`
   - `--window-size` / `--hop` は `ms/s/m/sample/samples` を受理
   - `sample(s)` を1つでも使う場合は `--target-sampling <n>hz` が必須
+  - STFT bin は `bin_no` / `db` の縦持ち行として保存（列数上限依存を回避）
 - `--progress` は interactive な `pwsh/cmd` で UTF-8 を適用し、`█/░` のバー表示を維持
 
 ## プロジェクト構成

--- a/SoundAnalyzer.Cli/README.md
+++ b/SoundAnalyzer.Cli/README.md
@@ -77,20 +77,24 @@ SoundAnalyzer.Cli.exe --window-size <len> --hop <len> --input-dir <path> --db-fi
 
 既定テーブル: `T_STFTAnalysis`
 
+- STFT bin は縦持ちで保存されます（1行 = 1bin）
 - `window` 列には入力指定値を保存します
 - hop が `ms/s/m` 指定のとき:
-  - 列: `idx`, `name`, `ch`, `window`, `ms`, `bin001..binNNN`, `create_at`, `modified_at`
-  - 一意制約: `(name, ch, window, ms)`
-  - インデックス: `(name)`, `(name, ch)`, `(name, ms)`, `(name, ch, ms)`
+  - 列: `idx`, `name`, `ch`, `window`, `ms`, `bin_no`, `db`, `create_at`, `modified_at`
+  - 一意制約: `(name, ch, window, ms, bin_no)`
+  - インデックス: `(name)`, `(name, ch)`, `(name, ms)`, `(name, ch, ms)`, `(name, ch, window, ms)`
 - hop が `sample/samples` 指定のとき:
-  - 列: `idx`, `name`, `ch`, `window`, `sample`, `bin001..binNNN`, `create_at`, `modified_at`
-  - 一意制約: `(name, ch, window, sample)`
-  - インデックス: `(name)`, `(name, ch)`, `(name, sample)`, `(name, ch, sample)`
+  - 列: `idx`, `name`, `ch`, `window`, `sample`, `bin_no`, `db`, `create_at`, `modified_at`
+  - 一意制約: `(name, ch, window, sample, bin_no)`
+  - インデックス: `(name)`, `(name, ch)`, `(name, sample)`, `(name, ch, sample)`, `(name, ch, window, sample)`
 
 `--delete-current` 未指定時は、既存テーブルの次を検証し不一致なら失敗します。
 
-- `binNNN` 列数と `--bin-count`
+- 既存データの `bin_no` 分布（`MAX(bin_no)` / `COUNT(DISTINCT bin_no)`）と `--bin-count`
 - hop 単位に対応するアンカー列（`ms` または `sample`）
+
+旧 wide 形式（`bin001..binNNN` 列）の STFT テーブルを検知した場合は互換実行せず失敗します。  
+その場合は `--delete-current` で再作成するか、`--table-name-override` で新規テーブルを指定してください。
 
 ## 音声処理の扱い
 

--- a/build-logs/2026-02-24T192815-stft-bin-normalized-build.txt
+++ b/build-logs/2026-02-24T192815-stft-bin-normalized-build.txt
@@ -1,0 +1,30 @@
+  復元対象のプロジェクトを決定しています...
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\AudioProcessor.Tests.csproj を復元しました (429 ミリ秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\AudioSplitter.Core.csproj を復元しました (429 ミリ秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\AudioSplitter.Cli.csproj を復元しました (429 ミリ秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\Cli.Shared.Tests.csproj を復元しました (429 ミリ秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\AudioSplitter.Core.Tests.csproj を復元しました (429 ミリ秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\PeakAnalyzer.Core.Tests.csproj を復元しました (429 ミリ秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\AudioSplitter.Cli.Tests.csproj を復元しました (429 ミリ秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\STFTAnalyzer.Core.Tests.csproj を復元しました (429 ミリ秒)。
+  14 個中 6 個の復元対象のプロジェクトは最新です。
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+
+ビルドに成功しました。
+    0 個の警告
+    0 エラー
+
+経過時間 00:00:09.11

--- a/build-logs/2026-02-24T192815-stft-bin-normalized-test.txt
+++ b/build-logs/2026-02-24T192815-stft-bin-normalized-test.txt
@@ -1,0 +1,65 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+VSTest のバージョン 18.0.1 (x64)
+
+
+テスト実行を開始しています。お待ちください...
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+VSTest のバージョン 18.0.1 (x64)
+
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+
+
+成功!   -失敗:     0、合格:    12、スキップ:     0、合計:    12、期間: 96 ms - AudioProcessor.Tests.dll (net10.0)
+テスト実行を開始しています。お待ちください...
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+
+成功!   -失敗:     0、合格:    13、スキップ:     0、合計:    13、期間: 709 ms - Cli.Shared.Tests.dll (net10.0)
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:     5、スキップ:     0、合計:     5、期間: 1 s - PeakAnalyzer.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:     6、スキップ:     0、合計:     6、期間: 691 ms - STFTAnalyzer.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:     8、スキップ:     0、合計:     8、期間: 676 ms - AudioSplitter.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    15、スキップ:     0、合計:    15、期間: 842 ms - AudioSplitter.Cli.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    43、スキップ:     0、合計:    43、期間: 1 s - SoundAnalyzer.Cli.Tests.dll (net10.0)


### PR DESCRIPTION
## 背景
stft-analysis の SQLite 保存は wide 形式（in001..binNNN 列）だったため、実ランタイム MAX_COLUMN=2000 制約で 	oo many columns が発生するケースがありました。

## 変更内容
- SqliteStftAnalysisStore を wide 形式から正規化（1行=1bin）へ変更
  - 列: idx,name,ch,window,<anchor>,bin_no,db,create_at,modified_at
  - 一意制約: (name,ch,window,<anchor>,bin_no)
  - Write は Bins をループして bin ごとに1行 INSERT
  - Upsert: db,modified_at を更新
  - SkipDuplicate: DO NOTHING
- 既存 wide 形式テーブル（in001..binNNN）を検知した場合は fail-fast
  - StftTableSchemaMismatch を返し、--delete-current または新テーブル名利用を案内
- 既存テーブルの bin-count 整合は MAX(bin_no) と COUNT(DISTINCT bin_no) で検証
  - データ行が 0 件のときは mismatch 判定を行わない
- SoundAnalyzer.Cli.Tests を新スキーマに合わせて更新
  - legacy-wide 検知テスト追加
  - inCount=3000 書き込みテスト追加（列上限再発防止）
- ドキュメント更新
  - SoundAnalyzer.Cli/README.md
  - README.md

## 破壊的変更
- 既存 wide 形式 STFT テーブルの自動移行は行いません。
- 既存 wide テーブルを利用する場合は --delete-current で再作成するか、--table-name-override で新規テーブルを指定してください。

## 検証
- dotnet build AudioProcessor.slnx -warnaserror
- dotnet test AudioProcessor.slnx
- dotnet run --project SoundAnalyzer.Cli -- --help
- dotnet run --project AudioSplitter.Cli -- --help

## ログ
- uild-logs/2026-02-24T192815-stft-bin-normalized-build.txt
- uild-logs/2026-02-24T192815-stft-bin-normalized-test.txt

Closes #15