### PR TITLE
feat(sound-analyzer): threaded analyze/insert pipeline with advanced show-progress

### DIFF
--- a/Cli.Shared.Tests/Extensions/CliSharedServiceCollectionExtensionsTests.cs
+++ b/Cli.Shared.Tests/Extensions/CliSharedServiceCollectionExtensionsTests.cs
@@ -8,7 +8,7 @@ namespace Cli.Shared.Tests.Extensions;
 public sealed class CliSharedServiceCollectionExtensionsTests
 {
     [Fact]
-    public void AddCliShared_ShouldRegisterFactoryAsSingleton()
+    public void AddCliShared_ShouldRegisterFactoriesAsSingleton()
     {
         ServiceCollection services = new();
 
@@ -17,8 +17,12 @@ public sealed class CliSharedServiceCollectionExtensionsTests
 
         IProgressDisplayFactory first = provider.GetRequiredService<IProgressDisplayFactory>();
         IProgressDisplayFactory second = provider.GetRequiredService<IProgressDisplayFactory>();
+        ITextBlockProgressDisplayFactory firstTextBlockFactory = provider.GetRequiredService<ITextBlockProgressDisplayFactory>();
+        ITextBlockProgressDisplayFactory secondTextBlockFactory = provider.GetRequiredService<ITextBlockProgressDisplayFactory>();
 
         Assert.Same(first, second);
         Assert.IsType<ProgressDisplayFactory>(first);
+        Assert.Same(firstTextBlockFactory, secondTextBlockFactory);
+        Assert.IsType<TextBlockProgressDisplayFactory>(firstTextBlockFactory);
     }
 }

--- a/Cli.Shared.Tests/Infrastructure/Console/TextBlockProgressDisplayFactoryTests.cs
+++ b/Cli.Shared.Tests/Infrastructure/Console/TextBlockProgressDisplayFactoryTests.cs
@@ -1,0 +1,119 @@
+using System.Text;
+using Cli.Shared.Application.Ports;
+using Cli.Shared.Infrastructure.Console;
+
+namespace Cli.Shared.Tests.Infrastructure.Console;
+
+public sealed class TextBlockProgressDisplayFactoryTests
+{
+    private static readonly Encoding LegacySingleByteEncoding = Encoding.ASCII;
+
+    [Fact]
+    public void Create_ShouldReturnNoOp_WhenDisabled()
+    {
+        TextBlockProgressDisplayFactory factory = new(
+            new FakeConsoleEnvironment(
+                isErrorRedirected: false,
+                isUserInteractive: true,
+                initialOutputEncoding: LegacySingleByteEncoding));
+
+        ITextBlockProgressDisplay display = factory.Create(enabled: false);
+
+        Assert.Same(NoOpTextBlockProgressDisplay.Instance, display);
+    }
+
+    [Fact]
+    public void Create_ShouldReturnNoOp_WhenErrorIsRedirected()
+    {
+        TextBlockProgressDisplayFactory factory = new(
+            new FakeConsoleEnvironment(
+                isErrorRedirected: true,
+                isUserInteractive: true,
+                initialOutputEncoding: LegacySingleByteEncoding));
+
+        ITextBlockProgressDisplay display = factory.Create(enabled: true);
+
+        Assert.Same(NoOpTextBlockProgressDisplay.Instance, display);
+    }
+
+    [Fact]
+    public void Create_ShouldReturnNoOp_WhenEnvironmentIsNonInteractive()
+    {
+        TextBlockProgressDisplayFactory factory = new(
+            new FakeConsoleEnvironment(
+                isErrorRedirected: false,
+                isUserInteractive: false,
+                initialOutputEncoding: LegacySingleByteEncoding));
+
+        ITextBlockProgressDisplay display = factory.Create(enabled: true);
+
+        Assert.Same(NoOpTextBlockProgressDisplay.Instance, display);
+    }
+
+    [Fact]
+    public void Create_ShouldReturnTextBlockDisplay_WhenEnabledAndInteractive()
+    {
+        FakeConsoleEnvironment environment = new(
+            isErrorRedirected: false,
+            isUserInteractive: true,
+            initialOutputEncoding: LegacySingleByteEncoding);
+        TextBlockProgressDisplayFactory factory = new(environment);
+
+        ITextBlockProgressDisplay display = factory.Create(enabled: true);
+
+        Assert.IsType<TextBlockProgressDisplay>(display);
+        Assert.Equal(["EnsureUtf8OutputEncoding", "ErrorWriter"], environment.CallSequence);
+    }
+
+    private sealed class FakeConsoleEnvironment : IConsoleEnvironment
+    {
+        private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
+
+        private EncodingAwareStringWriter? errorWriter;
+        private Encoding outputEncoding;
+
+        public FakeConsoleEnvironment(
+            bool isErrorRedirected,
+            bool isUserInteractive,
+            Encoding initialOutputEncoding)
+        {
+            IsErrorRedirected = isErrorRedirected;
+            IsUserInteractive = isUserInteractive;
+            outputEncoding = initialOutputEncoding;
+        }
+
+        public bool IsErrorRedirected { get; }
+
+        public bool IsUserInteractive { get; }
+
+        public List<string> CallSequence { get; } = new();
+
+        public void EnsureUtf8OutputEncoding()
+        {
+            CallSequence.Add("EnsureUtf8OutputEncoding");
+            outputEncoding = Utf8NoBom;
+        }
+
+        public TextWriter ErrorWriter
+        {
+            get
+            {
+                CallSequence.Add("ErrorWriter");
+                errorWriter ??= new EncodingAwareStringWriter(outputEncoding);
+                return errorWriter;
+            }
+        }
+    }
+
+    private sealed class EncodingAwareStringWriter : StringWriter
+    {
+        private readonly Encoding encoding;
+
+        public EncodingAwareStringWriter(Encoding encoding)
+        {
+            this.encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
+        }
+
+        public override Encoding Encoding => encoding;
+    }
+}

--- a/Cli.Shared.Tests/Infrastructure/Console/TextBlockProgressDisplayTests.cs
+++ b/Cli.Shared.Tests/Infrastructure/Console/TextBlockProgressDisplayTests.cs
@@ -1,0 +1,91 @@
+using Cli.Shared.Infrastructure.Console;
+
+namespace Cli.Shared.Tests.Infrastructure.Console;
+
+public sealed class TextBlockProgressDisplayTests
+{
+    [Fact]
+    public void Report_ShouldUseRelativeCursorSequences_WhenModeIsAnsiRelative()
+    {
+        StringWriter writer = new();
+        TextBlockProgressDisplay display = new(writer, CursorControlMode.AnsiRelative);
+
+        display.Report(["Line-1", "Line-2"], force: true);
+        display.Report(["Line-3", "Line-4"], force: true);
+
+        string text = writer.ToString();
+        Assert.Contains("\u001b[2A", text, StringComparison.Ordinal);
+        Assert.Contains("\u001b[2K\r", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Report_ShouldClearExtraRows_WhenLineCountDecreases()
+    {
+        StringWriter writer = new();
+        TextBlockProgressDisplay display = new(writer, CursorControlMode.AnsiRelative);
+
+        display.Report(["L1", "L2", "L3"], force: true);
+        display.Report(["L1"], force: true);
+
+        string text = writer.ToString();
+        Assert.Contains("\u001b[3A", text, StringComparison.Ordinal);
+        Assert.True(CountSubstring(text, "\u001b[2K\r") >= 4);
+    }
+
+    [Fact]
+    public void Report_ShouldPreserveAnsiTermination_WhenTruncated()
+    {
+        StringWriter writer = new();
+        ProgressBlockRenderer renderer = new(writer, CursorControlMode.AnsiRelative);
+        string longGreenLine = string.Create(
+            System.Globalization.CultureInfo.InvariantCulture,
+            $"\u001b[32m{new string('X', 300)}");
+
+        renderer.Render([longGreenLine]);
+
+        string text = writer.ToString();
+        Assert.Contains("\u001b[0m", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Complete_ShouldRenderLatestLinesAgain()
+    {
+        StringWriter writer = new();
+        TextBlockProgressDisplay display = new(writer, CursorControlMode.Disabled);
+
+        display.Report(["A", "B"], force: true);
+        int linesAfterReport = CountNonEmptyLines(writer.ToString());
+
+        display.Complete();
+        int linesAfterComplete = CountNonEmptyLines(writer.ToString());
+
+        Assert.True(linesAfterReport >= 2);
+        Assert.True(linesAfterComplete >= linesAfterReport + 2);
+    }
+
+    private static int CountSubstring(string source, string value)
+    {
+        int count = 0;
+        int index = 0;
+        while (index >= 0)
+        {
+            index = source.IndexOf(value, index, StringComparison.Ordinal);
+            if (index < 0)
+            {
+                break;
+            }
+
+            count++;
+            index += value.Length;
+        }
+
+        return count;
+    }
+
+    private static int CountNonEmptyLines(string text)
+    {
+        return text
+            .Split(Environment.NewLine, StringSplitOptions.None)
+            .Count(line => !string.IsNullOrEmpty(line));
+    }
+}

--- a/Cli.Shared/Application/Ports/ITextBlockProgressDisplay.cs
+++ b/Cli.Shared/Application/Ports/ITextBlockProgressDisplay.cs
@@ -1,0 +1,8 @@
+namespace Cli.Shared.Application.Ports;
+
+public interface ITextBlockProgressDisplay
+{
+    public void Report(IReadOnlyList<string> lines, bool force = false);
+
+    public void Complete();
+}

--- a/Cli.Shared/Application/Ports/ITextBlockProgressDisplayFactory.cs
+++ b/Cli.Shared/Application/Ports/ITextBlockProgressDisplayFactory.cs
@@ -1,0 +1,6 @@
+namespace Cli.Shared.Application.Ports;
+
+public interface ITextBlockProgressDisplayFactory
+{
+    public ITextBlockProgressDisplay Create(bool enabled);
+}

--- a/Cli.Shared/Extensions/CliSharedServiceCollectionExtensions.cs
+++ b/Cli.Shared/Extensions/CliSharedServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ public static class CliSharedServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddSingleton<IProgressDisplayFactory, ProgressDisplayFactory>();
+        services.AddSingleton<ITextBlockProgressDisplayFactory, TextBlockProgressDisplayFactory>();
         return services;
     }
 }

--- a/Cli.Shared/Infrastructure/Console/CursorControlMode.cs
+++ b/Cli.Shared/Infrastructure/Console/CursorControlMode.cs
@@ -1,0 +1,8 @@
+namespace Cli.Shared.Infrastructure.Console;
+
+internal enum CursorControlMode
+{
+    Disabled = 0,
+    AnsiRelative = 1,
+    ConsoleAbsolute = 2,
+}

--- a/Cli.Shared/Infrastructure/Console/NoOpTextBlockProgressDisplay.cs
+++ b/Cli.Shared/Infrastructure/Console/NoOpTextBlockProgressDisplay.cs
@@ -1,0 +1,22 @@
+using Cli.Shared.Application.Ports;
+
+namespace Cli.Shared.Infrastructure.Console;
+
+internal sealed class NoOpTextBlockProgressDisplay : ITextBlockProgressDisplay
+{
+    public static NoOpTextBlockProgressDisplay Instance { get; } = new();
+
+    private NoOpTextBlockProgressDisplay()
+    {
+    }
+
+    public void Report(IReadOnlyList<string> lines, bool force = false)
+    {
+        _ = lines;
+        _ = force;
+    }
+
+    public void Complete()
+    {
+    }
+}

--- a/Cli.Shared/Infrastructure/Console/ProgressBlockRenderer.cs
+++ b/Cli.Shared/Infrastructure/Console/ProgressBlockRenderer.cs
@@ -1,0 +1,294 @@
+using System.Globalization;
+using System.Text;
+
+namespace Cli.Shared.Infrastructure.Console;
+
+internal sealed class ProgressBlockRenderer
+{
+    private readonly TextWriter writer;
+    private CursorControlMode cursorControlMode;
+    private int originTop = -1;
+    private int renderedLineCount;
+
+    public ProgressBlockRenderer(TextWriter writer, CursorControlMode cursorControlMode)
+    {
+        this.writer = writer ?? throw new ArgumentNullException(nameof(writer));
+        this.cursorControlMode = cursorControlMode;
+    }
+
+    public void Render(IReadOnlyList<string> lines)
+    {
+        ArgumentNullException.ThrowIfNull(lines);
+
+        switch (cursorControlMode)
+        {
+            case CursorControlMode.AnsiRelative:
+                RenderWithAnsiRelativeCursor(lines);
+                break;
+            case CursorControlMode.ConsoleAbsolute:
+                RenderWithConsoleAbsoluteCursor(lines);
+                break;
+            default:
+                RenderAppendOnly(lines);
+                break;
+        }
+    }
+
+    public void Complete()
+    {
+        if (renderedLineCount <= 0)
+        {
+            return;
+        }
+
+        switch (cursorControlMode)
+        {
+            case CursorControlMode.AnsiRelative:
+                writer.WriteLine();
+                writer.Flush();
+                break;
+            case CursorControlMode.ConsoleAbsolute:
+                if (originTop >= 0)
+                {
+                    _ = TrySetCursorPosition(0, originTop + renderedLineCount);
+                }
+
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void RenderWithAnsiRelativeCursor(IReadOnlyList<string> lines)
+    {
+        int width = ResolveWidth();
+        int rows = Math.Max(renderedLineCount, lines.Count);
+        if (renderedLineCount > 0)
+        {
+            writer.Write(string.Create(CultureInfo.InvariantCulture, $"\u001b[{renderedLineCount}A"));
+        }
+
+        for (int i = 0; i < rows; i++)
+        {
+            writer.Write("\u001b[2K\r");
+            if (i < lines.Count)
+            {
+                WriteLineFixed(lines[i], width);
+            }
+            else
+            {
+                WriteLineFixed(string.Empty, width);
+            }
+        }
+
+        renderedLineCount = lines.Count;
+    }
+
+    private void RenderWithConsoleAbsoluteCursor(IReadOnlyList<string> lines)
+    {
+        if (originTop < 0)
+        {
+            originTop = GetCurrentCursorTop();
+        }
+        else
+        {
+            bool moved = TrySetCursorPosition(0, originTop);
+            if (!moved)
+            {
+                cursorControlMode = CursorControlMode.AnsiRelative;
+                RenderWithAnsiRelativeCursor(lines);
+                return;
+            }
+        }
+
+        int width = ResolveWidth();
+        for (int i = 0; i < lines.Count; i++)
+        {
+            WriteLineFixed(lines[i], width);
+        }
+
+        if (renderedLineCount > lines.Count)
+        {
+            for (int i = lines.Count; i < renderedLineCount; i++)
+            {
+                WriteLineFixed(string.Empty, width);
+            }
+        }
+
+        renderedLineCount = lines.Count;
+    }
+
+    private void RenderAppendOnly(IReadOnlyList<string> lines)
+    {
+        int width = ResolveWidth();
+        for (int i = 0; i < lines.Count; i++)
+        {
+            WriteLineFixed(lines[i], width);
+        }
+
+        renderedLineCount = lines.Count;
+    }
+
+    private void WriteLineFixed(string text, int width)
+    {
+        string safeText = TruncateToDisplayWidth(text, width);
+        writer.Write(safeText);
+        int displayLength = GetDisplayLength(safeText);
+        if (displayLength < width)
+        {
+            writer.Write(new string(' ', width - displayLength));
+        }
+
+        writer.WriteLine();
+        writer.Flush();
+    }
+
+    private static string TruncateToDisplayWidth(string text, int width)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        if (width <= 0 || text.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        StringBuilder builder = new(capacity: text.Length);
+        int displayLength = 0;
+        int index = 0;
+        bool styleActive = false;
+
+        while (index < text.Length && displayLength < width)
+        {
+            if (text[index] == '\u001b' && index + 1 < text.Length && text[index + 1] == '[')
+            {
+                if (!TryReadAnsiEscape(text, index, out int escapeEnd, out string? code))
+                {
+                    break;
+                }
+
+                builder.Append(text, index, escapeEnd - index + 1);
+                styleActive = code is not null && !string.Equals(code, "0", StringComparison.Ordinal);
+                index = escapeEnd + 1;
+                continue;
+            }
+
+            builder.Append(text[index]);
+            displayLength++;
+            index++;
+        }
+
+        while (index < text.Length && text[index] == '\u001b' && index + 1 < text.Length && text[index + 1] == '[')
+        {
+            if (!TryReadAnsiEscape(text, index, out int escapeEnd, out string? code))
+            {
+                break;
+            }
+
+            builder.Append(text, index, escapeEnd - index + 1);
+            styleActive = code is not null && !string.Equals(code, "0", StringComparison.Ordinal);
+            index = escapeEnd + 1;
+        }
+
+        if (styleActive)
+        {
+            builder.Append("\u001b[0m");
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool TryReadAnsiEscape(string text, int index, out int escapeEnd, out string? code)
+    {
+        escapeEnd = index;
+        code = null;
+
+        int cursor = index + 2;
+        while (cursor < text.Length && text[cursor] != 'm')
+        {
+            cursor++;
+        }
+
+        if (cursor >= text.Length)
+        {
+            return false;
+        }
+
+        code = text[(index + 2)..cursor];
+        escapeEnd = cursor;
+        return true;
+    }
+
+    private static int GetDisplayLength(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        int displayLength = 0;
+        int index = 0;
+        while (index < text.Length)
+        {
+            if (text[index] == '\u001b' && index + 1 < text.Length && text[index + 1] == '[')
+            {
+                int escapeTail = index + 2;
+                while (escapeTail < text.Length && text[escapeTail] != 'm')
+                {
+                    escapeTail++;
+                }
+
+                index = escapeTail < text.Length ? escapeTail + 1 : text.Length;
+                continue;
+            }
+
+            displayLength++;
+            index++;
+        }
+
+        return displayLength;
+    }
+
+    private static int ResolveWidth()
+    {
+        try
+        {
+            return Math.Max(60, System.Console.BufferWidth - 1);
+        }
+        catch (Exception ex) when (ex is IOException or ArgumentOutOfRangeException)
+        {
+            string? columnsText = Environment.GetEnvironmentVariable("COLUMNS");
+            bool parsed = int.TryParse(
+                columnsText,
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out int parsedColumns);
+            if (parsed && parsedColumns > 1)
+            {
+                return Math.Max(60, parsedColumns - 1);
+            }
+
+            return 80;
+        }
+    }
+
+    private static int GetCurrentCursorTop()
+    {
+        try
+        {
+            return System.Console.CursorTop;
+        }
+        catch (Exception ex) when (ex is IOException or ArgumentOutOfRangeException)
+        {
+            return 0;
+        }
+    }
+
+    private static bool TrySetCursorPosition(int left, int top)
+    {
+        try
+        {
+            System.Console.SetCursorPosition(left, top);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or ArgumentOutOfRangeException)
+        {
+            return false;
+        }
+    }
+}

--- a/Cli.Shared/Infrastructure/Console/TextBlockProgressDisplay.cs
+++ b/Cli.Shared/Infrastructure/Console/TextBlockProgressDisplay.cs
@@ -1,0 +1,54 @@
+using Cli.Shared.Application.Ports;
+
+namespace Cli.Shared.Infrastructure.Console;
+
+internal sealed class TextBlockProgressDisplay : ITextBlockProgressDisplay
+{
+    private static readonly TimeSpan MinRenderInterval = TimeSpan.FromMilliseconds(80);
+
+    private readonly object sync = new();
+    private readonly ProgressBlockRenderer renderer;
+    private DateTimeOffset lastRenderAt;
+    private string[] latestLines = Array.Empty<string>();
+
+    public TextBlockProgressDisplay(TextWriter writer)
+        : this(writer, CursorControlMode.Disabled)
+    {
+    }
+
+    internal TextBlockProgressDisplay(TextWriter writer, CursorControlMode cursorControlMode)
+    {
+        renderer = new ProgressBlockRenderer(writer ?? throw new ArgumentNullException(nameof(writer)), cursorControlMode);
+    }
+
+    public void Report(IReadOnlyList<string> lines, bool force = false)
+    {
+        ArgumentNullException.ThrowIfNull(lines);
+
+        lock (sync)
+        {
+            latestLines = lines.Count == 0 ? Array.Empty<string>() : lines.ToArray();
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            if (!force && now - lastRenderAt < MinRenderInterval)
+            {
+                return;
+            }
+
+            renderer.Render(latestLines);
+            lastRenderAt = now;
+        }
+    }
+
+    public void Complete()
+    {
+        lock (sync)
+        {
+            if (latestLines.Length > 0)
+            {
+                renderer.Render(latestLines);
+            }
+
+            renderer.Complete();
+        }
+    }
+}

--- a/Cli.Shared/Infrastructure/Console/TextBlockProgressDisplayFactory.cs
+++ b/Cli.Shared/Infrastructure/Console/TextBlockProgressDisplayFactory.cs
@@ -2,35 +2,35 @@ using Cli.Shared.Application.Ports;
 
 namespace Cli.Shared.Infrastructure.Console;
 
-internal sealed class ProgressDisplayFactory : IProgressDisplayFactory
+internal sealed class TextBlockProgressDisplayFactory : ITextBlockProgressDisplayFactory
 {
     private readonly IConsoleEnvironment consoleEnvironment;
 
-    public ProgressDisplayFactory()
+    public TextBlockProgressDisplayFactory()
         : this(new ConsoleEnvironment())
     {
     }
 
-    internal ProgressDisplayFactory(IConsoleEnvironment consoleEnvironment)
+    internal TextBlockProgressDisplayFactory(IConsoleEnvironment consoleEnvironment)
     {
         this.consoleEnvironment = consoleEnvironment ?? throw new ArgumentNullException(nameof(consoleEnvironment));
     }
 
-    public IProgressDisplay Create(bool enabled)
+    public ITextBlockProgressDisplay Create(bool enabled)
     {
         if (!enabled)
         {
-            return NoOpProgressDisplay.Instance;
+            return NoOpTextBlockProgressDisplay.Instance;
         }
 
         if (consoleEnvironment.IsErrorRedirected || !consoleEnvironment.IsUserInteractive)
         {
-            return NoOpProgressDisplay.Instance;
+            return NoOpTextBlockProgressDisplay.Instance;
         }
 
         consoleEnvironment.EnsureUtf8OutputEncoding();
         CursorControlMode cursorControlMode = ResolveCursorControlMode();
-        return new DualLineProgressDisplay(consoleEnvironment.ErrorWriter, cursorControlMode);
+        return new TextBlockProgressDisplay(consoleEnvironment.ErrorWriter, cursorControlMode);
     }
 
     private static CursorControlMode ResolveCursorControlMode()

--- a/Cli.Shared/README.md
+++ b/Cli.Shared/README.md
@@ -7,18 +7,21 @@
 現在の実装には、次の機能が含まれます。
 
 - `--progress` 指定時のみ有効化される 2 段プログレス表示
+- 複数行テキストブロックを上書き更新する再描画エンジン（`ITextBlockProgressDisplay`）
 - TTY 判定に基づく no-op 表示への自動フォールバック
 - `stdout` の機械可読出力を維持するための `stderr` への進捗出力
 - interactive な `pwsh/cmd` では UTF-8 を適用し、`█/░` の進捗バー表示を維持
 
-`SoundAnalyzer.Cli` の詳細進捗（`--show-progress`）は `SoundAnalyzer.Cli` 側の専用表示実装を利用します。  
-`Cli.Shared` の 2 段表示は主に `AudioSplitter.Cli` で利用されます。
+`Cli.Shared` の 2 段表示は主に `AudioSplitter.Cli` で利用されます。  
+`SoundAnalyzer.Cli` の詳細進捗（`--show-progress`）は `Cli.Shared` のテキストブロック描画エンジンを利用し、行データ生成のみを `SoundAnalyzer.Cli` 側で担います。
 
 ## 主な契約
 
 - `IProgressDisplay`
 - `IProgressDisplayFactory`
 - `DualProgressState`
+- `ITextBlockProgressDisplay`
+- `ITextBlockProgressDisplayFactory`
 
 ## DI 登録
 

--- a/Cli.Shared/README.md
+++ b/Cli.Shared/README.md
@@ -11,6 +11,9 @@
 - `stdout` の機械可読出力を維持するための `stderr` への進捗出力
 - interactive な `pwsh/cmd` では UTF-8 を適用し、`█/░` の進捗バー表示を維持
 
+`SoundAnalyzer.Cli` の詳細進捗（`--show-progress`）は `SoundAnalyzer.Cli` 側の専用表示実装を利用します。  
+`Cli.Shared` の 2 段表示は主に `AudioSplitter.Cli` で利用されます。
+
 ## 主な契約
 
 - `IProgressDisplay`

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ AudioProcessor は、オーディオ解析・変換ツール群を提供する .
 | パス | 種別 | 役割 |
 |---|---|---|
 | `AudioProcessor` | Library | 外部オーディオ処理エンジン連携、プローブ、PCM ストリーム読取、セグメント出力などの共通基盤 |
-| `Cli.Shared` | Library | CLI 表示共通化（2段プログレス表示、TTY判定、stderr描画） |
+| `Cli.Shared` | Library | CLI 表示共通化（2段プログレス表示、テキストブロック再描画、TTY判定、stderr描画） |
 | `AudioSplitter.Core` | Library | 無音分割ドメイン、境界計算、分割ユースケース |
 | `AudioSplitter.Cli` | CLI | 無音分割のコマンドライン実行層 |
 | `PeakAnalyzer.Core` | Library | hop/window ベースのピーク dB 窓解析コア |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AudioProcessor は、オーディオ解析・変換ツール群を提供する .
   - `sample(s)` を1つでも使う場合は `--target-sampling <n>hz` が必須
   - STFT bin は `bin_no` / `db` の縦持ち行として保存（列数上限依存を回避）
   - `--stft-proc-threads` / `--stft-file-threads` / `--insert-queue-size` で並列・キュー制御
-- `--show-progress` は interactive な `pwsh/cmd` で、Songs/Threads/Queue の詳細進捗を `stderr` に表示
+- `--show-progress` は interactive な `pwsh/cmd` で、Songs/Threads/Queue の詳細進捗を `stderr` に表示（Thread行は単一ゲージで Insert=緑 / Analyze=白 / 未処理=斑点）
 
 ## プロジェクト構成
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ AudioProcessor は、オーディオ解析・変換ツール群を提供する .
   - `--window-size` / `--hop` は `ms/s/m/sample/samples` を受理
   - `sample(s)` を1つでも使う場合は `--target-sampling <n>hz` が必須
   - STFT bin は `bin_no` / `db` の縦持ち行として保存（列数上限依存を回避）
-- `--progress` は interactive な `pwsh/cmd` で UTF-8 を適用し、`█/░` のバー表示を維持
+  - `--stft-proc-threads` / `--stft-file-threads` / `--insert-queue-size` で並列・キュー制御
+- `--show-progress` は interactive な `pwsh/cmd` で、Songs/Threads/Queue の詳細進捗を `stderr` に表示
 
 ## プロジェクト構成
 

--- a/STFTAnalyzer.Core/Application/Models/StftAnalysisRequest.cs
+++ b/STFTAnalyzer.Core/Application/Models/StftAnalysisRequest.cs
@@ -12,7 +12,8 @@ public sealed class StftAnalysisRequest
         long windowPersistedValue,
         int binCount,
         double minLimitDb,
-        string? ffmpegPath)
+        string? ffmpegPath,
+        int processingThreads = 1)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(inputFilePath);
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
@@ -21,6 +22,7 @@ public sealed class StftAnalysisRequest
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(analysisSampleRate);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(windowPersistedValue);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(binCount);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(processingThreads);
 
         if (double.IsNaN(minLimitDb) || double.IsInfinity(minLimitDb))
         {
@@ -37,6 +39,7 @@ public sealed class StftAnalysisRequest
         BinCount = binCount;
         MinLimitDb = minLimitDb;
         FfmpegPath = ffmpegPath;
+        ProcessingThreads = processingThreads;
     }
 
     public string InputFilePath { get; }
@@ -58,4 +61,6 @@ public sealed class StftAnalysisRequest
     public double MinLimitDb { get; }
 
     public string? FfmpegPath { get; }
+
+    public int ProcessingThreads { get; }
 }

--- a/STFTAnalyzer.Core/Application/UseCases/StftAnalysisUseCase.cs
+++ b/STFTAnalyzer.Core/Application/UseCases/StftAnalysisUseCase.cs
@@ -67,6 +67,13 @@ public sealed class StftAnalysisUseCase
                 request.BinCount.ToString(CultureInfo.InvariantCulture));
         }
 
+        if (request.ProcessingThreads <= 0)
+        {
+            throw new StftAnalysisException(
+                StftAnalysisErrorCode.InvalidBinCount,
+                request.ProcessingThreads.ToString(CultureInfo.InvariantCulture));
+        }
+
         if (double.IsNaN(request.MinLimitDb) || double.IsInfinity(request.MinLimitDb))
         {
             throw new StftAnalysisException(
@@ -105,7 +112,8 @@ public sealed class StftAnalysisUseCase
             request.AnchorUnit,
             request.BinCount,
             request.MinLimitDb,
-            pointWriter);
+            pointWriter,
+            request.ProcessingThreads);
 
         int? targetSampleRateHz = request.AnalysisSampleRate == streamInfo.SampleRate
             ? null

--- a/SoundAnalyzer.Cli.Tests/Infrastructure/Execution/BatchExecutionSupportTests.cs
+++ b/SoundAnalyzer.Cli.Tests/Infrastructure/Execution/BatchExecutionSupportTests.cs
@@ -1,0 +1,100 @@
+using AudioProcessor.Domain.Models;
+using SoundAnalyzer.Cli.Infrastructure.Execution;
+
+namespace SoundAnalyzer.Cli.Tests.Infrastructure.Execution;
+
+public sealed class BatchExecutionSupportTests
+{
+    [Fact]
+    public void TryEstimatePeakPointCountPerTarget_ShouldEstimate_WhenFramesAreAvailable()
+    {
+        AudioStreamInfo streamInfo = new(
+            sampleRate: 48000,
+            channels: 2,
+            pcmBitDepth: AudioPcmBitDepth.F32,
+            estimatedTotalFrames: 480000);
+
+        bool estimated = BatchExecutionSupport.TryEstimatePeakPointCountPerTarget(
+            streamInfo,
+            hopMs: 10,
+            out long pointCount);
+
+        Assert.True(estimated);
+        Assert.Equal(1000, pointCount);
+    }
+
+    [Fact]
+    public void TryEstimatePeakPointCountPerTarget_ShouldReturnFalse_WhenFramesAreMissing()
+    {
+        AudioStreamInfo streamInfo = new(
+            sampleRate: 48000,
+            channels: 2,
+            pcmBitDepth: AudioPcmBitDepth.F32,
+            estimatedTotalFrames: null);
+
+        bool estimated = BatchExecutionSupport.TryEstimatePeakPointCountPerTarget(
+            streamInfo,
+            hopMs: 10,
+            out long pointCount);
+
+        Assert.False(estimated);
+        Assert.Equal(0, pointCount);
+    }
+
+    [Fact]
+    public void TryEstimateStftPointCountPerFile_ShouldEstimate_WhenSampleRateIsUnchanged()
+    {
+        AudioStreamInfo streamInfo = new(
+            sampleRate: 48000,
+            channels: 2,
+            pcmBitDepth: AudioPcmBitDepth.F32,
+            estimatedTotalFrames: 480000);
+
+        bool estimated = BatchExecutionSupport.TryEstimateStftPointCountPerFile(
+            streamInfo,
+            analysisSampleRate: 48000,
+            hopSamples: 480,
+            out long pointCount);
+
+        Assert.True(estimated);
+        Assert.Equal(2000, pointCount);
+    }
+
+    [Fact]
+    public void TryEstimateStftPointCountPerFile_ShouldEstimate_WhenSampleRateIsResampled()
+    {
+        AudioStreamInfo streamInfo = new(
+            sampleRate: 48000,
+            channels: 2,
+            pcmBitDepth: AudioPcmBitDepth.F32,
+            estimatedTotalFrames: 480000);
+
+        bool estimated = BatchExecutionSupport.TryEstimateStftPointCountPerFile(
+            streamInfo,
+            analysisSampleRate: 44100,
+            hopSamples: 441,
+            out long pointCount);
+
+        Assert.True(estimated);
+        Assert.Equal(2000, pointCount);
+    }
+
+    [Fact]
+    public void TryEstimateStftPointCountPerFile_ShouldReturnFalse_WhenFramesAreMissing()
+    {
+        AudioStreamInfo streamInfo = new(
+            sampleRate: 48000,
+            channels: 2,
+            pcmBitDepth: AudioPcmBitDepth.F32,
+            estimatedTotalFrames: null);
+
+        bool estimated = BatchExecutionSupport.TryEstimateStftPointCountPerFile(
+            streamInfo,
+            analysisSampleRate: 44100,
+            hopSamples: 441,
+            out long pointCount);
+
+        Assert.False(estimated);
+        Assert.Equal(0, pointCount);
+    }
+}

--- a/SoundAnalyzer.Cli.Tests/Infrastructure/Progress/SoundAnalyzerProgressTrackerTests.cs
+++ b/SoundAnalyzer.Cli.Tests/Infrastructure/Progress/SoundAnalyzerProgressTrackerTests.cs
@@ -1,0 +1,146 @@
+using SoundAnalyzer.Cli.Infrastructure.Progress;
+
+namespace SoundAnalyzer.Cli.Tests.Infrastructure.Progress;
+
+public sealed class SoundAnalyzerProgressTrackerTests
+{
+    [Fact]
+    public void Complete_ShouldRenderMergedGauge_WithInsertAnalyzeAndPendingSegments_WhenExpectedIsKnown()
+    {
+        StringWriter writer = new();
+        using SoundAnalyzerProgressTracker tracker = SoundAnalyzerProgressTracker.CreateForTest(
+            ansiEnabled: false,
+            writer);
+
+        tracker.Configure(["song_001"], threadCount: 1, queueCapacity: 1024);
+        tracker.SetWorkerSong(0, "song_001");
+        tracker.SetSongExpectedPoints("song_001", expectedPoints: 10);
+
+        for (int i = 0; i < 6; i++)
+        {
+            tracker.IncrementEnqueued("song_001");
+        }
+
+        for (int i = 0; i < 3; i++)
+        {
+            tracker.IncrementInserted("song_001");
+        }
+
+        tracker.Complete();
+
+        string workerLine = FindLastWorkerLine(writer.ToString());
+        Assert.Contains("█", workerLine, StringComparison.Ordinal);
+        Assert.Contains("▓", workerLine, StringComparison.Ordinal);
+        Assert.Contains("░", workerLine, StringComparison.Ordinal);
+        Assert.Contains("A  60.0%", workerLine, StringComparison.Ordinal);
+        Assert.Contains("I  30.0%", workerLine, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Complete_ShouldRenderUnknownAsPending_WhenAnalyzeIsIncomplete()
+    {
+        StringWriter writer = new();
+        using SoundAnalyzerProgressTracker tracker = SoundAnalyzerProgressTracker.CreateForTest(
+            ansiEnabled: false,
+            writer);
+
+        tracker.Configure(["song_002"], threadCount: 1, queueCapacity: 1024);
+        tracker.SetWorkerSong(0, "song_002");
+        tracker.MarkSongExpectedPointsUnknown("song_002");
+
+        for (int i = 0; i < 5; i++)
+        {
+            tracker.IncrementEnqueued("song_002");
+        }
+
+        for (int i = 0; i < 2; i++)
+        {
+            tracker.IncrementInserted("song_002");
+        }
+
+        tracker.Complete();
+
+        string workerLine = FindLastWorkerLine(writer.ToString());
+        Assert.DoesNotContain("█", workerLine, StringComparison.Ordinal);
+        Assert.DoesNotContain("▓", workerLine, StringComparison.Ordinal);
+        Assert.Contains("░", workerLine, StringComparison.Ordinal);
+        Assert.Contains("A   0.0%", workerLine, StringComparison.Ordinal);
+        Assert.Contains("I   0.0%", workerLine, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Complete_ShouldUseInsertedOverEnqueuedAfterAnalyzeComplete_WhenExpectedIsUnknown()
+    {
+        StringWriter writer = new();
+        using SoundAnalyzerProgressTracker tracker = SoundAnalyzerProgressTracker.CreateForTest(
+            ansiEnabled: false,
+            writer);
+
+        tracker.Configure(["song_003"], threadCount: 1, queueCapacity: 1024);
+        tracker.SetWorkerSong(0, "song_003");
+        tracker.MarkSongExpectedPointsUnknown("song_003");
+
+        for (int i = 0; i < 10; i++)
+        {
+            tracker.IncrementEnqueued("song_003");
+        }
+
+        for (int i = 0; i < 4; i++)
+        {
+            tracker.IncrementInserted("song_003");
+        }
+
+        tracker.MarkWorkerAnalyzeCompleted(0);
+        tracker.Complete();
+
+        string workerLine = FindLastWorkerLine(writer.ToString());
+        Assert.Contains("█", workerLine, StringComparison.Ordinal);
+        Assert.Contains("▓", workerLine, StringComparison.Ordinal);
+        Assert.DoesNotContain("░", workerLine, StringComparison.Ordinal);
+        Assert.Contains("A 100.0%", workerLine, StringComparison.Ordinal);
+        Assert.Contains("I  40.0%", workerLine, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Complete_ShouldRenderAllGreen_WhenAnalyzeAndInsertAreComplete()
+    {
+        StringWriter writer = new();
+        using SoundAnalyzerProgressTracker tracker = SoundAnalyzerProgressTracker.CreateForTest(
+            ansiEnabled: false,
+            writer);
+
+        tracker.Configure(["song_004"], threadCount: 1, queueCapacity: 1024);
+        tracker.SetWorkerSong(0, "song_004");
+        tracker.SetSongExpectedPoints("song_004", expectedPoints: 10);
+
+        for (int i = 0; i < 10; i++)
+        {
+            tracker.IncrementEnqueued("song_004");
+            tracker.IncrementInserted("song_004");
+        }
+
+        tracker.MarkWorkerAnalyzeCompleted(0);
+        tracker.Complete();
+
+        string workerLine = FindLastWorkerLine(writer.ToString());
+        Assert.Contains("█", workerLine, StringComparison.Ordinal);
+        Assert.DoesNotContain("▓", workerLine, StringComparison.Ordinal);
+        Assert.DoesNotContain("░", workerLine, StringComparison.Ordinal);
+        Assert.Contains("A 100.0%", workerLine, StringComparison.Ordinal);
+        Assert.Contains("I 100.0%", workerLine, StringComparison.Ordinal);
+    }
+
+    private static string FindLastWorkerLine(string allText)
+    {
+        string[] lines = allText.Split(Environment.NewLine, StringSplitOptions.None);
+        for (int index = lines.Length - 1; index >= 0; index--)
+        {
+            if (lines[index].Contains("T01", StringComparison.Ordinal))
+            {
+                return lines[index];
+            }
+        }
+
+        return string.Empty;
+    }
+}

--- a/SoundAnalyzer.Cli.Tests/Presentation/Cli/Arguments/CommandLineParserTests.cs
+++ b/SoundAnalyzer.Cli.Tests/Presentation/Cli/Arguments/CommandLineParserTests.cs
@@ -114,7 +114,7 @@ public sealed class CommandLineParserTests
     }
 
     [Fact]
-    public void Parse_ShouldRejectStems_WhenModeIsStft()
+    public void Parse_ShouldWarnAndIgnoreStems_WhenModeIsStft()
     {
         string[] args =
         [
@@ -124,12 +124,16 @@ public sealed class CommandLineParserTests
 
         CommandLineParseResult result = CommandLineParser.Parse(args);
 
-        Assert.False(result.IsSuccess);
-        Assert.Contains(ConsoleTexts.StemsNotSupportedForStftText, result.Errors, StringComparer.Ordinal);
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Arguments);
+        Assert.Null(result.Arguments.Stems);
+        Assert.Contains(
+            result.Warnings,
+            warning => warning.Contains(ConsoleTexts.StemsOption, StringComparison.Ordinal));
     }
 
     [Fact]
-    public void Parse_ShouldRejectBinCount_WhenModeIsPeak()
+    public void Parse_ShouldWarnAndIgnoreBinCount_WhenModeIsPeak()
     {
         string[] args =
         [
@@ -139,38 +143,36 @@ public sealed class CommandLineParserTests
 
         CommandLineParseResult result = CommandLineParser.Parse(args);
 
-        Assert.False(result.IsSuccess);
-        Assert.Contains(ConsoleTexts.BinCountOnlyForStftText, result.Errors, StringComparer.Ordinal);
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Arguments);
+        Assert.Null(result.Arguments.BinCount);
+        Assert.Contains(
+            result.Warnings,
+            warning => warning.Contains(ConsoleTexts.BinCountOption, StringComparison.Ordinal));
     }
 
     [Fact]
-    public void Parse_ShouldRejectRecursive_WhenModeIsPeak()
+    public void Parse_ShouldWarnAndIgnoreRecursiveAndDeleteCurrent_WhenModeIsPeak()
     {
         string[] args =
         [
             .. BasePeakArgs,
             "--recursive",
-        ];
-
-        CommandLineParseResult result = CommandLineParser.Parse(args);
-
-        Assert.False(result.IsSuccess);
-        Assert.Contains(ConsoleTexts.RecursiveOnlyForStftText, result.Errors, StringComparer.Ordinal);
-    }
-
-    [Fact]
-    public void Parse_ShouldRejectDeleteCurrent_WhenModeIsPeak()
-    {
-        string[] args =
-        [
-            .. BasePeakArgs,
             "--delete-current",
         ];
 
         CommandLineParseResult result = CommandLineParser.Parse(args);
 
-        Assert.False(result.IsSuccess);
-        Assert.Contains(ConsoleTexts.DeleteCurrentOnlyForStftText, result.Errors, StringComparer.Ordinal);
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Arguments);
+        Assert.False(result.Arguments.Recursive);
+        Assert.False(result.Arguments.DeleteCurrent);
+        Assert.Contains(
+            result.Warnings,
+            warning => warning.Contains(ConsoleTexts.RecursiveOption, StringComparison.Ordinal));
+        Assert.Contains(
+            result.Warnings,
+            warning => warning.Contains(ConsoleTexts.DeleteCurrentOption, StringComparison.Ordinal));
     }
 
     [Fact]
@@ -239,54 +241,7 @@ public sealed class CommandLineParserTests
     }
 
     [Fact]
-    public void Parse_ShouldRequireTargetSampling_WhenWindowIsSampleAndHopIsMsInStft()
-    {
-        string[] args =
-        [
-            "--window-size", "2048sample",
-            "--hop", "10ms",
-            "--input-dir", "C:/input",
-            "--db-file", "C:/tmp/analysis.db",
-            "--mode", "stft-analysis",
-            "--bin-count", "12",
-        ];
-
-        CommandLineParseResult result = CommandLineParser.Parse(args);
-
-        Assert.False(result.IsSuccess);
-        Assert.Contains(
-            ConsoleTexts.WithValue(ConsoleTexts.MissingOptionPrefix, ConsoleTexts.TargetSamplingOption),
-            result.Errors,
-            StringComparer.Ordinal);
-    }
-
-    [Fact]
-    public void Parse_ShouldAcceptMixedUnitsWithTargetSampling_WhenModeIsStft()
-    {
-        string[] args =
-        [
-            "--window-size", "50ms",
-            "--hop", "512samples",
-            "--target-sampling", "48000hz",
-            "--input-dir", "C:/input",
-            "--db-file", "C:/tmp/analysis.db",
-            "--mode", "stft-analysis",
-            "--bin-count", "12",
-        ];
-
-        CommandLineParseResult result = CommandLineParser.Parse(args);
-
-        Assert.True(result.IsSuccess);
-        Assert.NotNull(result.Arguments);
-        Assert.Equal(AnalysisLengthUnit.Millisecond, result.Arguments.WindowUnit);
-        Assert.Equal(AnalysisLengthUnit.Sample, result.Arguments.HopUnit);
-        Assert.Equal(50, result.Arguments.WindowValue);
-        Assert.Equal(512, result.Arguments.HopValue);
-        Assert.Equal(48_000, result.Arguments.TargetSamplingHz);
-    }
-
-    [Fact]
-    public void Parse_ShouldRejectTargetSampling_WhenModeIsPeak()
+    public void Parse_ShouldWarnAndIgnoreTargetSampling_WhenModeIsPeak()
     {
         string[] args =
         [
@@ -300,8 +255,12 @@ public sealed class CommandLineParserTests
 
         CommandLineParseResult result = CommandLineParser.Parse(args);
 
-        Assert.False(result.IsSuccess);
-        Assert.Contains(ConsoleTexts.TargetSamplingOnlyForStftText, result.Errors, StringComparer.Ordinal);
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Arguments);
+        Assert.Null(result.Arguments.TargetSamplingHz);
+        Assert.Contains(
+            result.Warnings,
+            warning => warning.Contains(ConsoleTexts.TargetSamplingOption, StringComparison.Ordinal));
     }
 
     [Fact]
@@ -349,7 +308,23 @@ public sealed class CommandLineParserTests
     }
 
     [Fact]
-    public void Parse_ShouldEnableProgress_WhenProgressOptionIsSpecified()
+    public void Parse_ShouldEnableShowProgress_WhenShowProgressOptionIsSpecified()
+    {
+        string[] args =
+        [
+            .. BaseStftArgs,
+            "--show-progress",
+        ];
+
+        CommandLineParseResult result = CommandLineParser.Parse(args);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Arguments);
+        Assert.True(result.Arguments.ShowProgress);
+    }
+
+    [Fact]
+    public void Parse_ShouldRejectLegacyProgressOption()
     {
         string[] args =
         [
@@ -359,8 +334,47 @@ public sealed class CommandLineParserTests
 
         CommandLineParseResult result = CommandLineParser.Parse(args);
 
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            result.Errors,
+            error => error.Contains("--progress", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Parse_ShouldApplyThreadAndQueueDefaults_WhenNotSpecified()
+    {
+        CommandLineParseResult result = CommandLineParser.Parse(BaseStftArgs);
+
         Assert.True(result.IsSuccess);
         Assert.NotNull(result.Arguments);
-        Assert.True(result.Arguments.Progress);
+        Assert.Equal(1, result.Arguments.StftProcThreads);
+        Assert.Equal(1, result.Arguments.PeakProcThreads);
+        Assert.Equal(1, result.Arguments.StftFileThreads);
+        Assert.Equal(1, result.Arguments.PeakFileThreads);
+        Assert.Equal(1024, result.Arguments.InsertQueueSize);
+    }
+
+    [Fact]
+    public void Parse_ShouldParseThreadAndQueueOptions()
+    {
+        string[] args =
+        [
+            .. BaseStftArgs,
+            "--stft-proc-threads", "6",
+            "--peak-proc-threads", "4",
+            "--stft-file-threads", "3",
+            "--peak-file-threads", "2",
+            "--insert-queue-size", "4096",
+        ];
+
+        CommandLineParseResult result = CommandLineParser.Parse(args);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Arguments);
+        Assert.Equal(6, result.Arguments.StftProcThreads);
+        Assert.Equal(4, result.Arguments.PeakProcThreads);
+        Assert.Equal(3, result.Arguments.StftFileThreads);
+        Assert.Equal(2, result.Arguments.PeakFileThreads);
+        Assert.Equal(4096, result.Arguments.InsertQueueSize);
     }
 }

--- a/SoundAnalyzer.Cli/Infrastructure/Execution/BatchExecutionSupport.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Execution/BatchExecutionSupport.cs
@@ -1,3 +1,4 @@
+using AudioProcessor.Domain.Models;
 using SoundAnalyzer.Cli.Infrastructure.Sqlite;
 using SoundAnalyzer.Cli.Presentation.Cli.Arguments;
 
@@ -49,5 +50,63 @@ internal static class BatchExecutionSupport
 
         long converted = checked(durationMs * sampleRate / 1000);
         return Math.Max(1, converted);
+    }
+
+    public static bool TryEstimatePeakPointCountPerTarget(
+        AudioStreamInfo streamInfo,
+        long hopMs,
+        out long expectedPointCount)
+    {
+        ArgumentNullException.ThrowIfNull(streamInfo);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(hopMs);
+
+        expectedPointCount = 0;
+        if (!streamInfo.EstimatedTotalFrames.HasValue)
+        {
+            return false;
+        }
+
+        long totalFrames = streamInfo.EstimatedTotalFrames.Value;
+        long totalMs = checked(totalFrames * 1000 / streamInfo.SampleRate);
+        long estimatedPoints = totalMs / hopMs;
+        if (estimatedPoints <= 0)
+        {
+            return false;
+        }
+
+        expectedPointCount = estimatedPoints;
+        return true;
+    }
+
+    public static bool TryEstimateStftPointCountPerFile(
+        AudioStreamInfo streamInfo,
+        int analysisSampleRate,
+        long hopSamples,
+        out long expectedPointCount)
+    {
+        ArgumentNullException.ThrowIfNull(streamInfo);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(analysisSampleRate);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(hopSamples);
+
+        expectedPointCount = 0;
+        if (!streamInfo.EstimatedTotalFrames.HasValue)
+        {
+            return false;
+        }
+
+        long totalFrames = streamInfo.EstimatedTotalFrames.Value;
+        long analysisFrames = checked(
+            (long)Math.Round(
+                (double)totalFrames * analysisSampleRate / streamInfo.SampleRate,
+                MidpointRounding.AwayFromZero));
+        long anchorCount = analysisFrames / hopSamples;
+        long estimatedPoints = checked(anchorCount * streamInfo.Channels);
+        if (estimatedPoints <= 0)
+        {
+            return false;
+        }
+
+        expectedPointCount = estimatedPoints;
+        return true;
     }
 }

--- a/SoundAnalyzer.Cli/Infrastructure/Execution/BatchExecutionSupport.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Execution/BatchExecutionSupport.cs
@@ -1,6 +1,3 @@
-using AudioProcessor.Domain.Models;
-using Cli.Shared.Application.Models;
-using Cli.Shared.Application.Ports;
 using SoundAnalyzer.Cli.Infrastructure.Sqlite;
 using SoundAnalyzer.Cli.Presentation.Cli.Arguments;
 
@@ -45,49 +42,6 @@ internal static class BatchExecutionSupport
         }
     }
 
-    public static long EstimateAnchorCount(AudioStreamInfo streamInfo, long hopMs)
-    {
-        ArgumentNullException.ThrowIfNull(streamInfo);
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(hopMs);
-
-        if (!streamInfo.EstimatedTotalFrames.HasValue)
-        {
-            return 0;
-        }
-
-        long estimatedFrames = streamInfo.EstimatedTotalFrames.Value;
-        long elapsedMs = checked(estimatedFrames * 1000 / streamInfo.SampleRate);
-        if (elapsedMs <= 0)
-        {
-            return 0;
-        }
-
-        return elapsedMs / hopMs;
-    }
-
-    public static long EstimateAnchorCountBySamples(
-        AudioStreamInfo streamInfo,
-        int analysisSampleRate,
-        long hopSamples)
-    {
-        ArgumentNullException.ThrowIfNull(streamInfo);
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(analysisSampleRate);
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(hopSamples);
-
-        if (!streamInfo.EstimatedTotalFrames.HasValue)
-        {
-            return 0;
-        }
-
-        long estimatedFrames = ScaleFrameCount(streamInfo.EstimatedTotalFrames.Value, streamInfo.SampleRate, analysisSampleRate);
-        if (estimatedFrames <= 0)
-        {
-            return 0;
-        }
-
-        return estimatedFrames / hopSamples;
-    }
-
     public static long ConvertDurationMsToSamples(long durationMs, int sampleRate)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(durationMs);
@@ -95,61 +49,5 @@ internal static class BatchExecutionSupport
 
         long converted = checked(durationMs * sampleRate / 1000);
         return Math.Max(1, converted);
-    }
-
-    public static long ScaleFrameCount(long frameCount, int sourceSampleRate, int targetSampleRate)
-    {
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(frameCount);
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(sourceSampleRate);
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(targetSampleRate);
-
-        if (sourceSampleRate == targetSampleRate)
-        {
-            return frameCount;
-        }
-
-        return checked(frameCount * targetSampleRate / sourceSampleRate);
-    }
-
-    public static double ToRatio(long processed, long? total)
-    {
-        if (!total.HasValue || total.Value <= 0)
-        {
-            return 0;
-        }
-
-        double ratio = (double)processed / total.Value;
-        if (ratio <= 0)
-        {
-            return 0;
-        }
-
-        if (ratio >= 1)
-        {
-            return 1;
-        }
-
-        return ratio;
-    }
-
-    public static void ReportDualProgress(
-        IProgressDisplay progressDisplay,
-        string topLabel,
-        long topProcessed,
-        long? topTotal,
-        string bottomLabel,
-        long bottomProcessed,
-        long? bottomTotal)
-    {
-        ArgumentNullException.ThrowIfNull(progressDisplay);
-        ArgumentException.ThrowIfNullOrWhiteSpace(topLabel);
-        ArgumentException.ThrowIfNullOrWhiteSpace(bottomLabel);
-
-        progressDisplay.Report(
-            new DualProgressState(
-                topLabel,
-                ToRatio(topProcessed, topTotal),
-                bottomLabel,
-                ToRatio(bottomProcessed, bottomTotal)));
     }
 }

--- a/SoundAnalyzer.Cli/Infrastructure/Execution/PeakAnalysisBatchExecutor.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Execution/PeakAnalysisBatchExecutor.cs
@@ -1,14 +1,11 @@
-using System.Globalization;
-using AudioProcessor.Application.Models;
-using AudioProcessor.Application.Ports;
-using AudioProcessor.Domain.Models;
-using Cli.Shared.Application.Models;
-using Cli.Shared.Application.Ports;
+using System.Runtime.ExceptionServices;
+using System.Threading.Channels;
 using PeakAnalyzer.Core.Application.Models;
 using PeakAnalyzer.Core.Application.Ports;
 using PeakAnalyzer.Core.Application.UseCases;
 using PeakAnalyzer.Core.Domain.Models;
 using SoundAnalyzer.Cli.Infrastructure.FileSystem;
+using SoundAnalyzer.Cli.Infrastructure.Progress;
 using SoundAnalyzer.Cli.Infrastructure.Sqlite;
 using SoundAnalyzer.Cli.Presentation.Cli.Arguments;
 
@@ -17,33 +14,18 @@ namespace SoundAnalyzer.Cli.Infrastructure.Execution;
 internal sealed class PeakAnalysisBatchExecutor
 {
     private readonly PeakAnalysisUseCase peakAnalysisUseCase;
-    private readonly IFfmpegLocator ffmpegLocator;
-    private readonly IAudioProbeService audioProbeService;
 
-    public PeakAnalysisBatchExecutor(
-        PeakAnalysisUseCase peakAnalysisUseCase,
-        IFfmpegLocator ffmpegLocator,
-        IAudioProbeService audioProbeService)
+    public PeakAnalysisBatchExecutor(PeakAnalysisUseCase peakAnalysisUseCase)
     {
         this.peakAnalysisUseCase = peakAnalysisUseCase ?? throw new ArgumentNullException(nameof(peakAnalysisUseCase));
-        this.ffmpegLocator = ffmpegLocator ?? throw new ArgumentNullException(nameof(ffmpegLocator));
-        this.audioProbeService = audioProbeService ?? throw new ArgumentNullException(nameof(audioProbeService));
     }
 
+#pragma warning disable CA1031
     public async Task<PeakAnalysisBatchSummary> ExecuteAsync(
         CommandLineArguments arguments,
-        CancellationToken cancellationToken)
-    {
-        return await ExecuteAsync(arguments, SilentProgressDisplay.Instance, cancellationToken).ConfigureAwait(false);
-    }
-
-    public async Task<PeakAnalysisBatchSummary> ExecuteAsync(
-        CommandLineArguments arguments,
-        IProgressDisplay progressDisplay,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(arguments);
-        ArgumentNullException.ThrowIfNull(progressDisplay);
 
         if (!Directory.Exists(arguments.InputDirectoryPath))
         {
@@ -55,74 +37,135 @@ internal sealed class PeakAnalysisBatchExecutor
         ResolvedStemAudioFiles resolved = StemAudioFileResolver.Resolve(
             arguments.InputDirectoryPath,
             arguments.Stems);
-
+        List<SongBatch> songs = BuildSongBatches(resolved.Files);
         SqliteConflictMode conflictMode = BatchExecutionSupport.ResolveConflictMode(arguments);
 
-        long writtenPointCount = 0;
+        using SoundAnalyzerProgressTracker progressTracker = SoundAnalyzerProgressTracker.Create(arguments.ShowProgress);
+        progressTracker.Configure(
+            songs.Select(song => song.Name).ToArray(),
+            arguments.PeakFileThreads,
+            arguments.InsertQueueSize);
+
         using SqlitePeakAnalysisStore store = new(arguments.DbFilePath, arguments.TableName, conflictMode);
         store.Initialize();
 
-        IReadOnlyList<SongBatch> songs = await BuildSongBatchesAsync(resolved.Files, arguments, cancellationToken)
-            .ConfigureAwait(false);
-        long completedSongCount = 0;
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        CancellationToken executionToken = linkedCts.Token;
 
-        for (int songIndex = 0; songIndex < songs.Count; songIndex++)
+        BoundedChannelOptions insertChannelOptions = new(arguments.InsertQueueSize)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            SingleReader = true,
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.Wait,
+        };
 
-            SongBatch song = songs[songIndex];
-            long writtenForSong = 0;
-            ReportSongProgress(progressDisplay, song.Name, songs.Count, completedSongCount, writtenForSong, song.EstimatedPointCount);
+        Channel<QueuedPeakPoint> insertChannel = Channel.CreateBounded<QueuedPeakPoint>(insertChannelOptions);
+        Exception? consumerException = null;
+        long insertedPointCount = 0;
 
-            for (int targetIndex = 0; targetIndex < song.Targets.Count; targetIndex++)
+        Task consumerTask = Task.Run(
+            async () =>
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                StemAudioFile target = song.Targets[targetIndex];
-                PeakAnalysisRequest request = new(
-                    target.FilePath,
-                    target.Name,
-                    target.Stem,
-                    arguments.WindowSizeMs,
-                    arguments.HopMs,
-                    arguments.MinLimitDb,
-                    arguments.FfmpegPath);
-
-                ProgressReportingPeakWriter reportingWriter = new(
-                    store,
-                    pointCount =>
+                try
+                {
+                    await foreach (QueuedPeakPoint queuedPoint in insertChannel.Reader.ReadAllAsync(executionToken).ConfigureAwait(false))
                     {
-                        writtenForSong = checked(writtenForSong + pointCount);
-                        ReportSongProgress(
-                            progressDisplay,
-                            song.Name,
-                            songs.Count,
-                            completedSongCount,
-                            writtenForSong,
-                            song.EstimatedPointCount);
-                    });
+                        store.Write(queuedPoint.Point);
+                        insertedPointCount++;
+                        progressTracker.IncrementInserted(queuedPoint.SongName);
+                    }
+                }
+                catch (OperationCanceledException) when (executionToken.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    consumerException = ex;
+                    await linkedCts.CancelAsync().ConfigureAwait(false);
+                }
+            },
+            CancellationToken.None);
 
-                PeakAnalysisSummary summary = await peakAnalysisUseCase
-                    .ExecuteAsync(request, reportingWriter, cancellationToken)
-                    .ConfigureAwait(false);
+        QueuedPeakWriter queuedWriter = new(
+            insertChannel.Writer,
+            progressTracker,
+            () => consumerException,
+            executionToken);
 
-                writtenPointCount = checked(writtenPointCount + summary.PointCount);
+        Channel<SongBatch> songChannel = Channel.CreateUnbounded<SongBatch>(
+            new UnboundedChannelOptions
+            {
+                SingleWriter = true,
+                SingleReader = false,
+            });
+
+        for (int i = 0; i < songs.Count; i++)
+        {
+            if (!songChannel.Writer.TryWrite(songs[i]))
+            {
+                throw new InvalidOperationException("Failed to enqueue song job.");
             }
-
-            completedSongCount++;
-            ReportSongProgress(progressDisplay, song.Name, songs.Count, completedSongCount, song.EstimatedPointCount, song.EstimatedPointCount);
         }
 
-        if (songs.Count == 0)
+        songChannel.Writer.TryComplete();
+
+        Task[] workerTasks = new Task[arguments.PeakFileThreads];
+        for (int workerId = 0; workerId < workerTasks.Length; workerId++)
         {
-            BatchExecutionSupport.ReportDualProgress(
-                progressDisplay,
-                "Songs 0/0",
-                1,
-                1,
-                "Current song",
-                1,
-                1);
+            int capturedWorkerId = workerId;
+            workerTasks[workerId] = Task.Run(
+                async () =>
+                {
+                    await foreach (SongBatch song in songChannel.Reader.ReadAllAsync(executionToken).ConfigureAwait(false))
+                    {
+                        progressTracker.SetWorkerSong(capturedWorkerId, song.Name);
+                        try
+                        {
+                            await ProcessSongAsync(song, arguments, queuedWriter, executionToken).ConfigureAwait(false);
+                            progressTracker.MarkWorkerAnalyzeCompleted(capturedWorkerId);
+                        }
+                        finally
+                        {
+                            progressTracker.SetWorkerIdle(capturedWorkerId);
+                        }
+                    }
+                },
+                CancellationToken.None);
+        }
+
+        Exception? producerException = null;
+        try
+        {
+            await Task.WhenAll(workerTasks).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            producerException = ex;
+            await linkedCts.CancelAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            insertChannel.Writer.TryComplete(producerException);
+        }
+
+        try
+        {
+            await consumerTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (executionToken.IsCancellationRequested)
+        {
+            throw;
+        }
+
+        if (consumerException is not null)
+        {
+            throw new CliException(CliErrorCode.None, "Insert pipeline failed.", consumerException);
+        }
+
+        if (producerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(producerException).Throw();
         }
 
         store.Complete();
@@ -131,166 +174,127 @@ internal sealed class PeakAnalysisBatchExecutor
             resolved.DirectoryCount,
             resolved.Files.Count,
             resolved.SkippedStemCount,
-            writtenPointCount,
+            insertedPointCount,
             arguments.TableName);
     }
+#pragma warning restore CA1031
 
-    private async Task<IReadOnlyList<SongBatch>> BuildSongBatchesAsync(
-        IReadOnlyList<StemAudioFile> files,
+    private async Task ProcessSongAsync(
+        SongBatch song,
         CommandLineArguments arguments,
+        IPeakAnalysisPointWriter queuedWriter,
         CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(files);
+        ArgumentNullException.ThrowIfNull(song);
         ArgumentNullException.ThrowIfNull(arguments);
+        ArgumentNullException.ThrowIfNull(queuedWriter);
 
-        Dictionary<string, SongBatchBuilder> builders = new(StringComparer.OrdinalIgnoreCase);
-        List<string> orderedNames = new();
-        FfmpegToolPaths toolPaths = ffmpegLocator.Resolve(arguments.FfmpegPath);
+        ParallelOptions options = new()
+        {
+            CancellationToken = cancellationToken,
+            MaxDegreeOfParallelism = arguments.PeakProcThreads,
+        };
+
+        await Parallel.ForEachAsync(
+                song.Targets,
+                options,
+                async (target, token) =>
+                {
+                    PeakAnalysisRequest request = new(
+                        target.FilePath,
+                        target.Name,
+                        target.Stem,
+                        arguments.WindowSizeMs,
+                        arguments.HopMs,
+                        arguments.MinLimitDb,
+                        arguments.FfmpegPath);
+
+                    _ = await peakAnalysisUseCase
+                        .ExecuteAsync(request, queuedWriter, token)
+                        .ConfigureAwait(false);
+                })
+            .ConfigureAwait(false);
+    }
+
+    private static List<SongBatch> BuildSongBatches(IReadOnlyList<StemAudioFile> files)
+    {
+        ArgumentNullException.ThrowIfNull(files);
+
+        Dictionary<string, List<StemAudioFile>> groupedTargets = new(StringComparer.OrdinalIgnoreCase);
+        List<string> orderedSongNames = new();
 
         for (int i = 0; i < files.Count; i++)
         {
-            cancellationToken.ThrowIfCancellationRequested();
             StemAudioFile file = files[i];
-            if (!builders.TryGetValue(file.Name, out SongBatchBuilder? builder))
+            if (!groupedTargets.TryGetValue(file.Name, out List<StemAudioFile>? targets))
             {
-                builder = new SongBatchBuilder(file.Name);
-                builders[file.Name] = builder;
-                orderedNames.Add(file.Name);
+                targets = new List<StemAudioFile>();
+                groupedTargets[file.Name] = targets;
+                orderedSongNames.Add(file.Name);
             }
 
-            AudioStreamInfo streamInfo = await audioProbeService
-                .ProbeAsync(toolPaths, file.FilePath, cancellationToken)
-                .ConfigureAwait(false);
-            long estimatedPointCount = BatchExecutionSupport.EstimateAnchorCount(streamInfo, arguments.HopMs);
-
-            builder.Targets.Add(file);
-            builder.EstimatedPointCount = checked(builder.EstimatedPointCount + estimatedPointCount);
+            targets.Add(file);
         }
 
-        List<SongBatch> songs = new(orderedNames.Count);
-        for (int i = 0; i < orderedNames.Count; i++)
+        List<SongBatch> songs = new(orderedSongNames.Count);
+        for (int i = 0; i < orderedSongNames.Count; i++)
         {
-            SongBatchBuilder builder = builders[orderedNames[i]];
-            songs.Add(new SongBatch(builder.Name, builder.Targets, builder.EstimatedPointCount));
+            string songName = orderedSongNames[i];
+            songs.Add(new SongBatch(songName, groupedTargets[songName]));
         }
 
         return songs;
     }
 
-    private static void ReportSongProgress(
-        IProgressDisplay progressDisplay,
-        string songName,
-        int totalSongs,
-        long completedSongCount,
-        long songWrittenPoints,
-        long songEstimatedPoints)
+    private sealed class QueuedPeakWriter : IPeakAnalysisPointWriter
     {
-        ArgumentNullException.ThrowIfNull(progressDisplay);
-        ArgumentException.ThrowIfNullOrWhiteSpace(songName);
-        ArgumentOutOfRangeException.ThrowIfNegative(totalSongs);
-        ArgumentOutOfRangeException.ThrowIfNegative(completedSongCount);
-        ArgumentOutOfRangeException.ThrowIfNegative(songWrittenPoints);
-        ArgumentOutOfRangeException.ThrowIfNegative(songEstimatedPoints);
+        private readonly ChannelWriter<QueuedPeakPoint> writer;
+        private readonly SoundAnalyzerProgressTracker progressTracker;
+        private readonly CancellationToken cancellationToken;
+        private readonly Func<Exception?> consumerExceptionProvider;
 
-        long safeSongTotal = songEstimatedPoints > 0 ? songEstimatedPoints : Math.Max(songWrittenPoints, 1);
-        long safeTopTotal = totalSongs > 0 ? totalSongs : 1;
-        const long topScale = 1000;
-        long safeTopTotalScaled = checked(safeTopTotal * topScale);
-        long safeTopProcessedScaled = totalSongs > 0 ? checked(completedSongCount * topScale) : topScale;
-
-        double songRatio = BatchExecutionSupport.ToRatio(songWrittenPoints, safeSongTotal);
-        if (totalSongs > 0 && completedSongCount < safeTopTotal)
+        public QueuedPeakWriter(
+            ChannelWriter<QueuedPeakPoint> writer,
+            SoundAnalyzerProgressTracker progressTracker,
+            Func<Exception?> consumerExceptionProvider,
+            CancellationToken cancellationToken)
         {
-            safeTopProcessedScaled = Math.Min(
-                safeTopTotalScaled,
-                checked(safeTopProcessedScaled + (long)Math.Round(songRatio * topScale, MidpointRounding.AwayFromZero)));
+            this.writer = writer ?? throw new ArgumentNullException(nameof(writer));
+            this.progressTracker = progressTracker ?? throw new ArgumentNullException(nameof(progressTracker));
+            this.cancellationToken = cancellationToken;
+            this.consumerExceptionProvider = consumerExceptionProvider ?? throw new ArgumentNullException(nameof(consumerExceptionProvider));
         }
 
-        string topLabel = string.Create(
-            CultureInfo.InvariantCulture,
-            $"Songs {Math.Min(completedSongCount, safeTopTotal)}/{safeTopTotal} [{songName}]");
-        string bottomLabel = string.Create(
-            CultureInfo.InvariantCulture,
-            $"{songName} points {Math.Min(songWrittenPoints, safeSongTotal)}/{safeSongTotal}");
+        public void Write(PeakAnalysisPoint point)
+        {
+            ArgumentNullException.ThrowIfNull(point);
 
-        BatchExecutionSupport.ReportDualProgress(
-            progressDisplay,
-            topLabel,
-            safeTopProcessedScaled,
-            safeTopTotalScaled,
-            bottomLabel,
-            songWrittenPoints,
-            safeSongTotal);
+            Exception? consumerException = consumerExceptionProvider();
+            if (consumerException is not null)
+            {
+                throw new CliException(CliErrorCode.None, "Insert pipeline failed.", consumerException);
+            }
+
+            writer.WriteAsync(new QueuedPeakPoint(point.Name, point), cancellationToken).AsTask().GetAwaiter().GetResult();
+            progressTracker.IncrementEnqueued(point.Name);
+        }
     }
 
     private sealed class SongBatch
     {
-        public SongBatch(string name, IReadOnlyList<StemAudioFile> targets, long estimatedPointCount)
+        public SongBatch(string name, IReadOnlyList<StemAudioFile> targets)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(name);
             ArgumentNullException.ThrowIfNull(targets);
-            ArgumentOutOfRangeException.ThrowIfNegative(estimatedPointCount);
 
             Name = name;
             Targets = targets;
-            EstimatedPointCount = estimatedPointCount;
         }
 
         public string Name { get; }
 
         public IReadOnlyList<StemAudioFile> Targets { get; }
-
-        public long EstimatedPointCount { get; }
     }
 
-    private sealed class SongBatchBuilder
-    {
-        public SongBatchBuilder(string name)
-        {
-            ArgumentException.ThrowIfNullOrWhiteSpace(name);
-            Name = name;
-        }
-
-        public string Name { get; }
-
-        public List<StemAudioFile> Targets { get; } = new();
-
-        public long EstimatedPointCount { get; set; }
-    }
-
-    private sealed class ProgressReportingPeakWriter : IPeakAnalysisPointWriter
-    {
-        private readonly IPeakAnalysisPointWriter inner;
-        private readonly Action<int> onWrite;
-
-        public ProgressReportingPeakWriter(IPeakAnalysisPointWriter inner, Action<int> onWrite)
-        {
-            this.inner = inner ?? throw new ArgumentNullException(nameof(inner));
-            this.onWrite = onWrite ?? throw new ArgumentNullException(nameof(onWrite));
-        }
-
-        public void Write(PeakAnalysisPoint point)
-        {
-            inner.Write(point);
-            onWrite(1);
-        }
-    }
-
-    private sealed class SilentProgressDisplay : IProgressDisplay
-    {
-        public static SilentProgressDisplay Instance { get; } = new();
-
-        private SilentProgressDisplay()
-        {
-        }
-
-        public void Report(DualProgressState state)
-        {
-            _ = state;
-        }
-
-        public void Complete()
-        {
-        }
-    }
+    private readonly record struct QueuedPeakPoint(string SongName, PeakAnalysisPoint Point);
 }

--- a/SoundAnalyzer.Cli/Infrastructure/Execution/StftAnalysisBatchExecutor.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Execution/StftAnalysisBatchExecutor.cs
@@ -3,6 +3,7 @@ using System.Threading.Channels;
 using AudioProcessor.Application.Models;
 using AudioProcessor.Application.Ports;
 using AudioProcessor.Domain.Models;
+using Cli.Shared.Application.Ports;
 using STFTAnalyzer.Core.Application.Models;
 using STFTAnalyzer.Core.Application.Ports;
 using STFTAnalyzer.Core.Application.UseCases;
@@ -19,15 +20,18 @@ internal sealed class StftAnalysisBatchExecutor
     private readonly StftAnalysisUseCase stftAnalysisUseCase;
     private readonly IFfmpegLocator ffmpegLocator;
     private readonly IAudioProbeService audioProbeService;
+    private readonly ITextBlockProgressDisplayFactory progressDisplayFactory;
 
     public StftAnalysisBatchExecutor(
         StftAnalysisUseCase stftAnalysisUseCase,
         IFfmpegLocator ffmpegLocator,
-        IAudioProbeService audioProbeService)
+        IAudioProbeService audioProbeService,
+        ITextBlockProgressDisplayFactory progressDisplayFactory)
     {
         this.stftAnalysisUseCase = stftAnalysisUseCase ?? throw new ArgumentNullException(nameof(stftAnalysisUseCase));
         this.ffmpegLocator = ffmpegLocator ?? throw new ArgumentNullException(nameof(ffmpegLocator));
         this.audioProbeService = audioProbeService ?? throw new ArgumentNullException(nameof(audioProbeService));
+        this.progressDisplayFactory = progressDisplayFactory ?? throw new ArgumentNullException(nameof(progressDisplayFactory));
     }
 
 #pragma warning disable CA1031
@@ -50,7 +54,9 @@ internal sealed class StftAnalysisBatchExecutor
             arguments.InputDirectoryPath,
             arguments.Recursive);
 
-        using SoundAnalyzerProgressTracker progressTracker = SoundAnalyzerProgressTracker.Create(arguments.ShowProgress);
+        using SoundAnalyzerProgressTracker progressTracker = SoundAnalyzerProgressTracker.Create(
+            arguments.ShowProgress,
+            progressDisplayFactory);
         progressTracker.Configure(
             resolved.Files.Select(file => file.Name).ToArray(),
             arguments.StftFileThreads,

--- a/SoundAnalyzer.Cli/Infrastructure/Progress/SoundAnalyzerProgressTracker.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Progress/SoundAnalyzerProgressTracker.cs
@@ -1,0 +1,474 @@
+using System.Globalization;
+using System.Text;
+
+namespace SoundAnalyzer.Cli.Infrastructure.Progress;
+
+internal sealed class SoundAnalyzerProgressTracker : IDisposable
+{
+    private const int QueueBarWidth = 24;
+    private static readonly TimeSpan MinRenderInterval = TimeSpan.FromMilliseconds(80);
+
+    private readonly object sync = new();
+    private readonly bool enabled;
+    private readonly bool ansiEnabled;
+    private readonly TextWriter writer;
+    private readonly Dictionary<string, SongState> songs = new(StringComparer.OrdinalIgnoreCase);
+
+    private WorkerState[] workers = Array.Empty<WorkerState>();
+    private DateTimeOffset lastRenderAt;
+    private int originTop = -1;
+    private int renderedLineCount;
+    private long totalSongs;
+    private long totalEnqueued;
+    private long totalInserted;
+    private int queueCapacity = 1;
+    private bool disposed;
+
+    private SoundAnalyzerProgressTracker(bool enabled, bool ansiEnabled, TextWriter writer)
+    {
+        this.enabled = enabled;
+        this.ansiEnabled = ansiEnabled;
+        this.writer = writer ?? throw new ArgumentNullException(nameof(writer));
+    }
+
+    public static SoundAnalyzerProgressTracker Create(bool showProgress)
+    {
+        if (!showProgress)
+        {
+            return new SoundAnalyzerProgressTracker(false, false, TextWriter.Null);
+        }
+
+        bool interactive = !System.Console.IsErrorRedirected && Environment.UserInteractive;
+        if (!interactive)
+        {
+            return new SoundAnalyzerProgressTracker(false, false, TextWriter.Null);
+        }
+
+        System.Console.OutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        bool ansiEnabled = IsAnsiEnabled();
+        return new SoundAnalyzerProgressTracker(true, ansiEnabled, System.Console.Error);
+    }
+
+    public void Configure(IReadOnlyList<string> songNames, int threadCount, int queueCapacity)
+    {
+        ArgumentNullException.ThrowIfNull(songNames);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(threadCount);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(queueCapacity);
+
+        lock (sync)
+        {
+            ThrowIfDisposed();
+
+            songs.Clear();
+            for (int i = 0; i < songNames.Count; i++)
+            {
+                string songName = songNames[i];
+                if (string.IsNullOrWhiteSpace(songName))
+                {
+                    continue;
+                }
+
+                songs[songName] = new SongState();
+            }
+
+            workers = new WorkerState[threadCount];
+            for (int i = 0; i < workers.Length; i++)
+            {
+                workers[i] = new WorkerState();
+            }
+
+            totalSongs = songNames.Count;
+            totalEnqueued = 0;
+            totalInserted = 0;
+            this.queueCapacity = queueCapacity;
+
+            Render(force: true);
+        }
+    }
+
+    public void SetWorkerSong(int workerId, string songName)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(workerId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(songName);
+
+        lock (sync)
+        {
+            ThrowIfDisposed();
+            WorkerState worker = GetWorker(workerId);
+            worker.IsActive = true;
+            worker.SongName = songName;
+            worker.AnalyzeCompleted = false;
+            EnsureSong(songName);
+            Render();
+        }
+    }
+
+    public void MarkWorkerAnalyzeCompleted(int workerId)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(workerId);
+
+        lock (sync)
+        {
+            ThrowIfDisposed();
+            WorkerState worker = GetWorker(workerId);
+            if (!string.IsNullOrWhiteSpace(worker.SongName)
+                && songs.TryGetValue(worker.SongName, out SongState? songState))
+            {
+                songState.AnalyzeCompleted = true;
+            }
+
+            worker.AnalyzeCompleted = true;
+            Render();
+        }
+    }
+
+    public void SetWorkerIdle(int workerId)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(workerId);
+
+        lock (sync)
+        {
+            ThrowIfDisposed();
+            WorkerState worker = GetWorker(workerId);
+            worker.IsActive = false;
+            worker.SongName = string.Empty;
+            worker.AnalyzeCompleted = false;
+            Render();
+        }
+    }
+
+    public void IncrementEnqueued(string songName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(songName);
+
+        lock (sync)
+        {
+            ThrowIfDisposed();
+            SongState songState = EnsureSong(songName);
+            songState.Enqueued++;
+            totalEnqueued++;
+            Render();
+        }
+    }
+
+    public void IncrementInserted(string songName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(songName);
+
+        lock (sync)
+        {
+            ThrowIfDisposed();
+            SongState songState = EnsureSong(songName);
+            songState.Inserted++;
+            totalInserted++;
+            Render();
+        }
+    }
+
+    public void Complete()
+    {
+        lock (sync)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            Render(force: true);
+            if (enabled && renderedLineCount > 0 && originTop >= 0)
+            {
+                TrySetCursorPosition(0, originTop + renderedLineCount);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (sync)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            Complete();
+            disposed = true;
+        }
+    }
+
+    private void Render(bool force = false)
+    {
+        if (!enabled)
+        {
+            return;
+        }
+
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        if (!force && now - lastRenderAt < MinRenderInterval)
+        {
+            return;
+        }
+
+        RenderCore();
+        lastRenderAt = now;
+    }
+
+    private void RenderCore()
+    {
+        List<string> lines = BuildLines();
+        int width = ResolveWidth();
+
+        if (originTop < 0)
+        {
+            originTop = GetCurrentCursorTop();
+        }
+        else
+        {
+            TrySetCursorPosition(0, originTop);
+        }
+
+        for (int i = 0; i < lines.Count; i++)
+        {
+            WriteLineFixed(lines[i], width);
+        }
+
+        if (renderedLineCount > lines.Count)
+        {
+            for (int i = lines.Count; i < renderedLineCount; i++)
+            {
+                WriteLineFixed(string.Empty, width);
+            }
+        }
+
+        renderedLineCount = lines.Count;
+    }
+
+    private List<string> BuildLines()
+    {
+        long completedSongs = songs.Values.LongCount(static state => state.AnalyzeCompleted && state.Inserted >= state.Enqueued);
+        long safeTotalSongs = totalSongs > 0 ? totalSongs : 1;
+
+        string songsLine = string.Create(
+            CultureInfo.InvariantCulture,
+            $"Songs {Math.Min(completedSongs, safeTotalSongs)}/{safeTotalSongs}");
+
+        string workerCircles = string.Join(
+            " ",
+            workers.Select(worker => worker.IsActive ? PaintGreen("●") : PaintGray("●")));
+        string threadsLine = string.Create(CultureInfo.InvariantCulture, $"Threads {workerCircles}");
+
+        long queueDepth = Math.Max(0, totalEnqueued - totalInserted);
+        double queueRatio = ClampRatio(queueCapacity > 0 ? (double)queueDepth / queueCapacity : 0);
+        int filled = checked((int)Math.Round(queueRatio * QueueBarWidth, MidpointRounding.AwayFromZero));
+        if (filled > QueueBarWidth)
+        {
+            filled = QueueBarWidth;
+        }
+
+        char[] queueChars = new char[QueueBarWidth];
+        for (int i = 0; i < queueChars.Length; i++)
+        {
+            queueChars[i] = i < filled ? '█' : '░';
+        }
+
+        string queueBar = new(queueChars);
+        string queuePercent = (queueRatio * 100.0).ToString("0.0", CultureInfo.InvariantCulture);
+        string queueLine = string.Create(
+            CultureInfo.InvariantCulture,
+            $"Queue {queuePercent,6}% |{queueBar}| {queueDepth}/{queueCapacity}");
+
+        List<string> lines = new(3 + workers.Length)
+        {
+            songsLine,
+            threadsLine,
+            queueLine,
+        };
+
+        for (int i = 0; i < workers.Length; i++)
+        {
+            WorkerState worker = workers[i];
+            string active = worker.IsActive ? PaintGreen("●") : PaintGray("●");
+            string songLabel = string.IsNullOrWhiteSpace(worker.SongName) ? "(idle)" : worker.SongName;
+            string analyzeState = ResolveAnalyzeState(worker);
+            string insertState = ResolveInsertState(worker);
+
+            string line = string.Create(
+                CultureInfo.InvariantCulture,
+                $"T{i + 1:00} {active} {songLabel,-32} Analyze:{analyzeState} Insert:{insertState}");
+            lines.Add(line);
+        }
+
+        return lines;
+    }
+
+    private string ResolveAnalyzeState(WorkerState worker)
+    {
+        if (string.IsNullOrWhiteSpace(worker.SongName))
+        {
+            return "-";
+        }
+
+        if (worker.AnalyzeCompleted)
+        {
+            return PaintWhite("●");
+        }
+
+        return PaintGray("○");
+    }
+
+    private string ResolveInsertState(WorkerState worker)
+    {
+        if (string.IsNullOrWhiteSpace(worker.SongName))
+        {
+            return "-";
+        }
+
+        if (!songs.TryGetValue(worker.SongName, out SongState? songState))
+        {
+            return PaintGray("○");
+        }
+
+        bool insertCompleted = songState.AnalyzeCompleted && songState.Inserted >= songState.Enqueued;
+        return insertCompleted ? PaintGreen("●") : PaintGray("○");
+    }
+
+    private SongState EnsureSong(string songName)
+    {
+        if (!songs.TryGetValue(songName, out SongState? songState))
+        {
+            songState = new SongState();
+            songs[songName] = songState;
+        }
+
+        return songState;
+    }
+
+    private WorkerState GetWorker(int workerId)
+    {
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(workerId, workers.Length);
+
+        return workers[workerId];
+    }
+
+    private string PaintGreen(string text) => Paint(text, "32");
+
+    private string PaintGray(string text) => Paint(text, "90");
+
+    private string PaintWhite(string text) => Paint(text, "97");
+
+    private string Paint(string text, string code)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        ArgumentNullException.ThrowIfNull(code);
+
+        if (!ansiEnabled)
+        {
+            return text;
+        }
+
+        return string.Create(CultureInfo.InvariantCulture, $"\u001b[{code}m{text}\u001b[0m");
+    }
+
+    private void WriteLineFixed(string text, int width)
+    {
+        string safeText = text.Length <= width ? text : text[..width];
+        writer.Write(safeText);
+        if (safeText.Length < width)
+        {
+            writer.Write(new string(' ', width - safeText.Length));
+        }
+
+        writer.WriteLine();
+        writer.Flush();
+    }
+
+    private static bool IsAnsiEnabled()
+    {
+        string? term = Environment.GetEnvironmentVariable("TERM");
+        if (term is not null && term.Equals("dumb", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static int ResolveWidth()
+    {
+        try
+        {
+            return Math.Max(60, System.Console.BufferWidth - 1);
+        }
+        catch (Exception ex) when (ex is IOException or ArgumentOutOfRangeException)
+        {
+            return 160;
+        }
+    }
+
+    private static int GetCurrentCursorTop()
+    {
+        try
+        {
+            return System.Console.CursorTop;
+        }
+        catch (Exception ex) when (ex is IOException or ArgumentOutOfRangeException)
+        {
+            return 0;
+        }
+    }
+
+    private void TrySetCursorPosition(int left, int top)
+    {
+        try
+        {
+            System.Console.SetCursorPosition(left, top);
+        }
+        catch (Exception ex) when (ex is IOException or ArgumentOutOfRangeException)
+        {
+            originTop = GetCurrentCursorTop();
+        }
+    }
+
+    private static double ClampRatio(double ratio)
+    {
+        if (double.IsNaN(ratio) || double.IsInfinity(ratio))
+        {
+            return 0;
+        }
+
+        if (ratio <= 0)
+        {
+            return 0;
+        }
+
+        if (ratio >= 1)
+        {
+            return 1;
+        }
+
+        return ratio;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+    }
+
+    private sealed class SongState
+    {
+        public long Enqueued { get; set; }
+
+        public long Inserted { get; set; }
+
+        public bool AnalyzeCompleted { get; set; }
+    }
+
+    private sealed class WorkerState
+    {
+        public bool IsActive { get; set; }
+
+        public string SongName { get; set; } = string.Empty;
+
+        public bool AnalyzeCompleted { get; set; }
+    }
+}

--- a/SoundAnalyzer.Cli/Middleware/Entry.cs
+++ b/SoundAnalyzer.Cli/Middleware/Entry.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using AudioProcessor.Application.Errors;
+using Cli.Shared.Extensions;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -121,6 +122,7 @@ internal static class Entry
     {
         HostApplicationBuilder builder = Host.CreateApplicationBuilder();
 
+        builder.Services.AddCliShared();
         builder.Services.AddPeakAnalyzerCore();
         builder.Services.AddStftAnalyzerCore();
         builder.Services.AddSingleton<PeakAnalysisBatchExecutor>();

--- a/SoundAnalyzer.Cli/Middleware/Entry.cs
+++ b/SoundAnalyzer.Cli/Middleware/Entry.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using AudioProcessor.Application.Errors;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
@@ -162,6 +163,7 @@ internal static class Entry
             Warnings = warnings;
         }
 
+        [JsonPropertyName("warnings")]
         public IReadOnlyList<string> Warnings { get; }
     }
 }

--- a/SoundAnalyzer.Cli/Presentation/Cli/Arguments/CommandLineArguments.cs
+++ b/SoundAnalyzer.Cli/Presentation/Cli/Arguments/CommandLineArguments.cs
@@ -20,7 +20,12 @@ internal sealed class CommandLineArguments
         bool deleteCurrent,
         bool recursive,
         string? ffmpegPath,
-        bool progress)
+        int stftProcThreads,
+        int peakProcThreads,
+        int stftFileThreads,
+        int peakFileThreads,
+        int insertQueueSize,
+        bool showProgress)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(windowValue);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(hopValue);
@@ -28,6 +33,11 @@ internal sealed class CommandLineArguments
         ArgumentException.ThrowIfNullOrWhiteSpace(dbFilePath);
         ArgumentException.ThrowIfNullOrWhiteSpace(mode);
         ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(stftProcThreads);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(peakProcThreads);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(stftFileThreads);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(peakFileThreads);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(insertQueueSize);
 
         if (targetSamplingHz.HasValue)
         {
@@ -61,7 +71,12 @@ internal sealed class CommandLineArguments
         DeleteCurrent = deleteCurrent;
         Recursive = recursive;
         FfmpegPath = ffmpegPath;
-        Progress = progress;
+        StftProcThreads = stftProcThreads;
+        PeakProcThreads = peakProcThreads;
+        StftFileThreads = stftFileThreads;
+        PeakFileThreads = peakFileThreads;
+        InsertQueueSize = insertQueueSize;
+        ShowProgress = showProgress;
     }
 
     public long WindowValue { get; }
@@ -98,7 +113,17 @@ internal sealed class CommandLineArguments
 
     public string? FfmpegPath { get; }
 
-    public bool Progress { get; }
+    public int StftProcThreads { get; }
+
+    public int PeakProcThreads { get; }
+
+    public int StftFileThreads { get; }
+
+    public int PeakFileThreads { get; }
+
+    public int InsertQueueSize { get; }
+
+    public bool ShowProgress { get; }
 
     public bool UsesSampleUnit => WindowUnit == AnalysisLengthUnit.Sample || HopUnit == AnalysisLengthUnit.Sample;
 

--- a/SoundAnalyzer.Cli/Presentation/Cli/Arguments/CommandLineParseResult.cs
+++ b/SoundAnalyzer.Cli/Presentation/Cli/Arguments/CommandLineParseResult.cs
@@ -6,14 +6,17 @@ internal sealed class CommandLineParseResult
         bool isSuccess,
         bool isHelpRequested,
         CommandLineArguments? arguments,
-        IReadOnlyList<string> errors)
+        IReadOnlyList<string> errors,
+        IReadOnlyList<string> warnings)
     {
         ArgumentNullException.ThrowIfNull(errors);
+        ArgumentNullException.ThrowIfNull(warnings);
 
         IsSuccess = isSuccess;
         IsHelpRequested = isHelpRequested;
         Arguments = arguments;
         Errors = errors;
+        Warnings = warnings;
     }
 
     public bool IsSuccess { get; }
@@ -24,20 +27,27 @@ internal sealed class CommandLineParseResult
 
     public IReadOnlyList<string> Errors { get; }
 
-    public static CommandLineParseResult Success(CommandLineArguments arguments)
+    public IReadOnlyList<string> Warnings { get; }
+
+    public static CommandLineParseResult Success(CommandLineArguments arguments, IReadOnlyList<string>? warnings = null)
     {
         ArgumentNullException.ThrowIfNull(arguments);
-        return new CommandLineParseResult(true, false, arguments, Array.Empty<string>());
+        return new CommandLineParseResult(
+            true,
+            false,
+            arguments,
+            Array.Empty<string>(),
+            warnings ?? Array.Empty<string>());
     }
 
     public static CommandLineParseResult Help()
     {
-        return new CommandLineParseResult(false, true, null, Array.Empty<string>());
+        return new CommandLineParseResult(false, true, null, Array.Empty<string>(), Array.Empty<string>());
     }
 
     public static CommandLineParseResult Failure(IReadOnlyList<string> errors)
     {
         ArgumentNullException.ThrowIfNull(errors);
-        return new CommandLineParseResult(false, false, null, errors);
+        return new CommandLineParseResult(false, false, null, errors, Array.Empty<string>());
     }
 }

--- a/SoundAnalyzer.Cli/Presentation/Cli/Texts/ConsoleTexts.cs
+++ b/SoundAnalyzer.Cli/Presentation/Cli/Texts/ConsoleTexts.cs
@@ -18,8 +18,13 @@ internal static class ConsoleTexts
     public const string BinCountOption = "--bin-count";
     public const string DeleteCurrentOption = "--delete-current";
     public const string RecursiveOption = "--recursive";
+    public const string StftProcThreadsOption = "--stft-proc-threads";
+    public const string PeakProcThreadsOption = "--peak-proc-threads";
+    public const string StftFileThreadsOption = "--stft-file-threads";
+    public const string PeakFileThreadsOption = "--peak-file-threads";
+    public const string InsertQueueSizeOption = "--insert-queue-size";
     public const string FfmpegPathOption = "--ffmpeg-path";
-    public const string ProgressOption = "--progress";
+    public const string ShowProgressOption = "--show-progress";
     public const string HelpOption = "--help";
     public const string ShortHelpOption = "-h";
 
@@ -51,13 +56,18 @@ Optional:
   --bin-count <n>           STFT mode only. Number of output bands (required in stft-analysis)
   --delete-current          STFT mode only. Drop current table before processing
   --recursive               STFT mode only. Scan files recursively from input-dir
+  --stft-proc-threads <n>   STFT mode only. Processing threads per file (default: 1)
+  --peak-proc-threads <n>   Peak mode only. Processing threads per song (default: 1)
+  --stft-file-threads <n>   STFT mode only. Number of files analyzed in parallel (default: 1)
+  --peak-file-threads <n>   Peak mode only. Number of songs analyzed in parallel (default: 1)
+  --insert-queue-size <n>   Bounded queue size between analyze and DB insert (default: 1024)
   --ffmpeg-path <path>      ffmpeg executable path or directory containing ffmpeg/ffprobe
-  --progress                Show two-line progress bars on interactive stderr
+  --show-progress           Show advanced progress UI on interactive stderr
   --help, -h                Show help
 
 Examples:
-  SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --mode peak-analysis --stems Piano,Drums --table-name-override T_PEAK --upsert
-  SoundAnalyzer.Cli.exe --window-size 2048samples --hop 512samples --target-sampling 44100hz --input-dir /path/to/dir --db-file /path/to/file.db --mode stft-analysis --bin-count 12 --table-name-override T_STFT --upsert --recursive
+  SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --mode peak-analysis --stems Piano,Drums --peak-file-threads 2 --peak-proc-threads 4 --insert-queue-size 2048 --show-progress
+  SoundAnalyzer.Cli.exe --window-size 2048samples --hop 512samples --target-sampling 44100hz --input-dir /path/to/dir --db-file /path/to/file.db --mode stft-analysis --bin-count 12 --stft-file-threads 2 --stft-proc-threads 6 --insert-queue-size 4096 --show-progress
 """;
 
     public const string MissingOptionPrefix = "Missing required option: ";
@@ -71,12 +81,8 @@ Examples:
     public const string InvalidTableNamePrefix = "Invalid table name: ";
     public const string InvalidStemsText = "--stems must contain at least one stem name when specified.";
     public const string UpsertSkipConflictText = "--upsert and --skip-duplicate cannot be specified together.";
-    public const string BinCountOnlyForStftText = "--bin-count can only be used with --mode stft-analysis.";
-    public const string DeleteCurrentOnlyForStftText = "--delete-current can only be used with --mode stft-analysis.";
-    public const string RecursiveOnlyForStftText = "--recursive can only be used with --mode stft-analysis.";
-    public const string StemsNotSupportedForStftText = "--stems is not supported with --mode stft-analysis.";
     public const string SampleUnitOnlyForStftText = "sample/sample(s) units are only supported with --mode stft-analysis.";
-    public const string TargetSamplingOnlyForStftText = "--target-sampling can only be used with --mode stft-analysis when sample/sample(s) units are used.";
+    public const string IncompatibleOptionIgnoredPrefix = "Option is ignored for current mode: ";
 
     public const string InputDirectoryNotFoundPrefix = "Input directory does not exist: ";
     public const string FailedToCreateDbDirectoryPrefix = "Failed to create db directory: ";

--- a/SoundAnalyzer.Cli/README.md
+++ b/SoundAnalyzer.Cli/README.md
@@ -54,6 +54,8 @@ SoundAnalyzer.Cli.exe --window-size <len> --hop <len> --input-dir <path> --db-fi
   - 単一ゲージ上で `Insert済=緑`、`Analyze済未Insert=白`、`未処理=斑点` を表示
   - 通常は Analyze が Insert より先行して伸び、Insert が追従して緑化します
   - `EstimatedTotalFrames` が取得できないSongは Analyze完了まで不確定表示（斑点中心）とし、Analyze完了後は `inserted/enqueued` でInsertドレインを表示します
+  - `name` 列幅は固定12で表示します
+  - `Songs` / `Queue` / `Thread` はゲージ開始列を共通化し、横位置を揃えて表示します
 
 ### `stft-analysis` の追加制約
 

--- a/SoundAnalyzer.Cli/README.md
+++ b/SoundAnalyzer.Cli/README.md
@@ -34,7 +34,7 @@ SoundAnalyzer.Cli.exe --window-size <len> --hop <len> --input-dir <path> --db-fi
 | `--insert-queue-size <n>` | 任意 | 解析と DB Insert の間に置く bounded queue の容量（既定 `1024`） |
 | `--stems <csv>` | 任意 | `peak-analysis` のみ。解析対象 stem |
 | `--ffmpeg-path <path>` | 任意 | 音声処理ツールのパス指定（現行実装では ffmpeg/ffprobe） |
-| `--show-progress` | 任意 | 対話端末で詳細進捗表示（Songs/Threads/Queue）を有効化（`stderr` 出力） |
+| `--show-progress` | 任意 | 対話端末で詳細進捗表示（Songs/Threads/Queue）を有効化（`stderr` 出力）。Thread行は単一ゲージ（Insert=緑、Analyze-only=白、未処理=斑点） |
 | `--help`, `-h` | 任意 | ヘルプ表示 |
 
 ### 単位/サンプリング規則
@@ -44,6 +44,16 @@ SoundAnalyzer.Cli.exe --window-size <len> --hop <len> --input-dir <path> --db-fi
 - `sample(s)` を1つでも使う場合は `--target-sampling <n>hz` が必須です（例: `44100hz`）。
 - モード不一致オプションはエラーではなく warning として無視されます（`stderr` に JSON の `warnings` を出力）。
 - 互換性注意: `--progress` は廃止され、`--show-progress` のみ受理します。
+
+### `--show-progress` 表示仕様
+
+- Songs: 完了Song数/全体 + 進捗バー
+- Threads: file worker の稼働状態（緑丸/灰丸）
+- Queue: Insert queue 占有率（`(enqueued-inserted)/capacity`）
+- Thread行ゲージ:
+  - 単一ゲージ上で `Insert済=緑`、`Analyze済未Insert=白`、`未処理=斑点` を表示
+  - 通常は Analyze が Insert より先行して伸び、Insert が追従して緑化します
+  - `EstimatedTotalFrames` が取得できないSongは Analyze完了まで不確定表示（斑点中心）とし、Analyze完了後は `inserted/enqueued` でInsertドレインを表示します
 
 ### `stft-analysis` の追加制約
 

--- a/SoundAnalyzer.Cli/README.md
+++ b/SoundAnalyzer.Cli/README.md
@@ -27,9 +27,14 @@ SoundAnalyzer.Cli.exe --window-size <len> --hop <len> --input-dir <path> --db-fi
 | `--bin-count <n>` | 条件付き必須 | `stft-analysis` のみ必須（`n >= 1`） |
 | `--delete-current` | 任意 | `stft-analysis` のみ。既存テーブルを削除して再作成 |
 | `--recursive` | 任意 | `stft-analysis` のみ。`input-dir` 配下を再帰走査 |
+| `--stft-proc-threads <n>` | 任意 | `stft-analysis` のみ。1ファイル内の解析処理スレッド数（既定 `1`） |
+| `--peak-proc-threads <n>` | 任意 | `peak-analysis` のみ。1 Song 内の解析処理スレッド数（既定 `1`） |
+| `--stft-file-threads <n>` | 任意 | `stft-analysis` のみ。同時解析ファイル数（既定 `1`） |
+| `--peak-file-threads <n>` | 任意 | `peak-analysis` のみ。同時解析 Song 数（既定 `1`） |
+| `--insert-queue-size <n>` | 任意 | 解析と DB Insert の間に置く bounded queue の容量（既定 `1024`） |
 | `--stems <csv>` | 任意 | `peak-analysis` のみ。解析対象 stem |
 | `--ffmpeg-path <path>` | 任意 | 音声処理ツールのパス指定（現行実装では ffmpeg/ffprobe） |
-| `--progress` | 任意 | 対話端末で2段プログレス表示を有効化（`stderr` 出力） |
+| `--show-progress` | 任意 | 対話端末で詳細進捗表示（Songs/Threads/Queue）を有効化（`stderr` 出力） |
 | `--help`, `-h` | 任意 | ヘルプ表示 |
 
 ### 単位/サンプリング規則
@@ -37,7 +42,8 @@ SoundAnalyzer.Cli.exe --window-size <len> --hop <len> --input-dir <path> --db-fi
 - `sample` / `samples` は `stft-analysis` 専用です。`peak-analysis` ではエラーになります。
 - `window` と `hop` の単位混在は許可します（例: `window=50ms`, `hop=512samples`）。
 - `sample(s)` を1つでも使う場合は `--target-sampling <n>hz` が必須です（例: `44100hz`）。
-- `peak-analysis` で `--target-sampling` を指定するとエラーになります。
+- モード不一致オプションはエラーではなく warning として無視されます（`stderr` に JSON の `warnings` を出力）。
+- 互換性注意: `--progress` は廃止され、`--show-progress` のみ受理します。
 
 ### `stft-analysis` の追加制約
 
@@ -112,13 +118,13 @@ SoundAnalyzer.Cli.exe --window-size <len> --hop <len> --input-dir <path> --db-fi
 ### peak-analysis
 
 ```powershell
-SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --mode peak-analysis --stems Piano,Drums,Vocals --table-name-override T_PEAK --upsert
+SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --mode peak-analysis --stems Piano,Drums,Vocals --peak-file-threads 2 --peak-proc-threads 4 --insert-queue-size 2048 --table-name-override T_PEAK --upsert --show-progress
 ```
 
 ### stft-analysis (ms基準)
 
 ```powershell
-SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --mode stft-analysis --bin-count 12 --table-name-override T_STFT --upsert --recursive --delete-current --progress
+SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --mode stft-analysis --bin-count 12 --stft-file-threads 2 --stft-proc-threads 6 --insert-queue-size 4096 --table-name-override T_STFT --upsert --recursive --delete-current --show-progress
 ```
 
 ### stft-analysis (samples基準)

--- a/SoundAnalyzer.Cli/SoundAnalyzer.Cli.csproj
+++ b/SoundAnalyzer.Cli/SoundAnalyzer.Cli.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\Cli.Shared\Cli.Shared.csproj" />
     <ProjectReference Include="..\PeakAnalyzer.Core\PeakAnalyzer.Core.csproj" />
     <ProjectReference Include="..\STFTAnalyzer.Core\STFTAnalyzer.Core.csproj" />
   </ItemGroup>

--- a/SoundAnalyzer.Cli/SoundAnalyzer.Cli.csproj
+++ b/SoundAnalyzer.Cli/SoundAnalyzer.Cli.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <ProjectReference Include="..\Cli.Shared\Cli.Shared.csproj" />
     <ProjectReference Include="..\PeakAnalyzer.Core\PeakAnalyzer.Core.csproj" />
     <ProjectReference Include="..\STFTAnalyzer.Core\STFTAnalyzer.Core.csproj" />
   </ItemGroup>

--- a/build-logs/2026-02-24T203408-issue17-thread-queue-audiosplitter-help.txt
+++ b/build-logs/2026-02-24T203408-issue17-thread-queue-audiosplitter-help.txt
@@ -1,0 +1,19 @@
+Usage:
+  AudioSplitter.Cli.exe (--input-file <path> | --input-dir <path>) --output-dir <path> --level <dBFS> --duration <time> [options]
+
+Required options:
+  --input-file <path>       Input audio file path (wav/flac/m4a/caf)
+  --input-dir <path>        Input directory path
+  --output-dir <path>       Output directory path
+  --level <dBFS>            Silence threshold in dBFS, negative value only
+  --duration <time>         Silence duration threshold (e.g. 2000ms, 2s, 1m)
+
+Optional:
+  --recursive               Scan input directory recursively (available with --input-dir)
+  --after-offset <time>     Keep this duration from silence start in previous segment (default: 0ms)
+  --resume-offset <time>    Offset from next sound start for next segment, negative allowed (default: 0ms)
+  --resolution-type <spec>  Output resolution: 16bit|24bit|32float,<rate>hz
+  --ffmpeg-path <path>      ffmpeg executable path or directory containing ffmpeg/ffprobe
+  --progress                Show two-line progress bars on interactive stderr
+  -y                        Overwrite output without confirmation
+  --help, -h                Show help

--- a/build-logs/2026-02-24T203408-issue17-thread-queue-build.txt
+++ b/build-logs/2026-02-24T203408-issue17-thread-queue-build.txt
@@ -1,0 +1,22 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+
+ビルドに成功しました。
+    0 個の警告
+    0 エラー
+
+経過時間 00:00:05.04

--- a/build-logs/2026-02-24T203408-issue17-thread-queue-soundanalyzer-help.txt
+++ b/build-logs/2026-02-24T203408-issue17-thread-queue-soundanalyzer-help.txt
@@ -1,0 +1,32 @@
+Usage:
+  SoundAnalyzer.Cli.exe --window-size <len> --hop <len> --input-dir <path> --db-file <path> --mode <peak-analysis|stft-analysis> [options]
+
+Required options:
+  --window-size <len>       Analysis window size (ms/s/m/sample/samples)
+  --hop <len>               Hop size (ms/s/m/sample/samples)
+  --input-dir <path>        Input root directory
+  --db-file <path>          SQLite db file path
+  --mode <value>            peak-analysis or stft-analysis
+
+Optional:
+  --target-sampling <n>hz   Required when window/hop uses sample(s) in stft mode
+  --stems <csv>             Peak mode only. Stem names to analyze (case-insensitive)
+  --table-name-override <n> Override table name (default: peak=T_PeakAnalysis, stft=T_STFTAnalysis)
+  --upsert                  Upsert by unique key
+  --skip-duplicate          Skip duplicates by unique key
+  --min-limit-db <dB>       Clamp lower dB bound for all windows/bins (default: -120.0)
+  --bin-count <n>           STFT mode only. Number of output bands (required in stft-analysis)
+  --delete-current          STFT mode only. Drop current table before processing
+  --recursive               STFT mode only. Scan files recursively from input-dir
+  --stft-proc-threads <n>   STFT mode only. Processing threads per file (default: 1)
+  --peak-proc-threads <n>   Peak mode only. Processing threads per song (default: 1)
+  --stft-file-threads <n>   STFT mode only. Number of files analyzed in parallel (default: 1)
+  --peak-file-threads <n>   Peak mode only. Number of songs analyzed in parallel (default: 1)
+  --insert-queue-size <n>   Bounded queue size between analyze and DB insert (default: 1024)
+  --ffmpeg-path <path>      ffmpeg executable path or directory containing ffmpeg/ffprobe
+  --show-progress           Show advanced progress UI on interactive stderr
+  --help, -h                Show help
+
+Examples:
+  SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --mode peak-analysis --stems Piano,Drums --peak-file-threads 2 --peak-proc-threads 4 --insert-queue-size 2048 --show-progress
+  SoundAnalyzer.Cli.exe --window-size 2048samples --hop 512samples --target-sampling 44100hz --input-dir /path/to/dir --db-file /path/to/file.db --mode stft-analysis --bin-count 12 --stft-file-threads 2 --stft-proc-threads 6 --insert-queue-size 4096 --show-progress

--- a/build-logs/2026-02-24T203408-issue17-thread-queue-test.txt
+++ b/build-logs/2026-02-24T203408-issue17-thread-queue-test.txt
@@ -1,0 +1,65 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+VSTest のバージョン 18.0.1 (x64)
+
+C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+テスト実行を開始しています。お待ちください...
+VSTest のバージョン 18.0.1 (x64)
+
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+VSTest のバージョン 18.0.1 (x64)
+
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+テスト実行を開始しています。お待ちください...
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:    12、スキップ:     0、合計:    12、期間: 119 ms - AudioProcessor.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    13、スキップ:     0、合計:    13、期間: 226 ms - Cli.Shared.Tests.dll (net10.0)
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+
+成功!   -失敗:     0、合格:     5、スキップ:     0、合計:     5、期間: 121 ms - PeakAnalyzer.Core.Tests.dll (net10.0)
+テスト実行を開始しています。お待ちください...
+
+成功!   -失敗:     0、合格:     7、スキップ:     0、合計:     7、期間: 133 ms - STFTAnalyzer.Core.Tests.dll (net10.0)
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:     8、スキップ:     0、合計:     8、期間: 155 ms - AudioSplitter.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    15、スキップ:     0、合計:    15、期間: 310 ms - AudioSplitter.Cli.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    43、スキップ:     0、合計:    43、期間: 703 ms - SoundAnalyzer.Cli.Tests.dll (net10.0)

--- a/build-logs/2026-02-24T203632-issue17-thread-queue-build.txt
+++ b/build-logs/2026-02-24T203632-issue17-thread-queue-build.txt
@@ -1,0 +1,22 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+
+ビルドに成功しました。
+    0 個の警告
+    0 エラー
+
+経過時間 00:00:04.50

--- a/build-logs/2026-02-24T203632-issue17-thread-queue-test.txt
+++ b/build-logs/2026-02-24T203632-issue17-thread-queue-test.txt
@@ -1,0 +1,65 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+テスト実行を開始しています。お待ちください...
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+VSTest のバージョン 18.0.1 (x64)
+
+C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+
+成功!   -失敗:     0、合格:    12、スキップ:     0、合計:    12、期間: 107 ms - AudioProcessor.Tests.dll (net10.0)
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:    13、スキップ:     0、合計:    13、期間: 657 ms - Cli.Shared.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:     8、スキップ:     0、合計:     8、期間: 626 ms - AudioSplitter.Core.Tests.dll (net10.0)
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+VSTest のバージョン 18.0.1 (x64)
+
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+テスト実行を開始しています。お待ちください...
+VSTest のバージョン 18.0.1 (x64)
+
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:     7、スキップ:     0、合計:     7、期間: 687 ms - STFTAnalyzer.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:     5、スキップ:     0、合計:     5、期間: 777 ms - PeakAnalyzer.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    15、スキップ:     0、合計:    15、期間: 828 ms - AudioSplitter.Cli.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    43、スキップ:     0、合計:    43、期間: 1 s - SoundAnalyzer.Cli.Tests.dll (net10.0)

--- a/build-logs/2026-02-24T204702-progress-bar-fix-help-soundanalyzer.txt
+++ b/build-logs/2026-02-24T204702-progress-bar-fix-help-soundanalyzer.txt
@@ -1,0 +1,32 @@
+Usage:
+  SoundAnalyzer.Cli.exe --window-size <len> --hop <len> --input-dir <path> --db-file <path> --mode <peak-analysis|stft-analysis> [options]
+
+Required options:
+  --window-size <len>       Analysis window size (ms/s/m/sample/samples)
+  --hop <len>               Hop size (ms/s/m/sample/samples)
+  --input-dir <path>        Input root directory
+  --db-file <path>          SQLite db file path
+  --mode <value>            peak-analysis or stft-analysis
+
+Optional:
+  --target-sampling <n>hz   Required when window/hop uses sample(s) in stft mode
+  --stems <csv>             Peak mode only. Stem names to analyze (case-insensitive)
+  --table-name-override <n> Override table name (default: peak=T_PeakAnalysis, stft=T_STFTAnalysis)
+  --upsert                  Upsert by unique key
+  --skip-duplicate          Skip duplicates by unique key
+  --min-limit-db <dB>       Clamp lower dB bound for all windows/bins (default: -120.0)
+  --bin-count <n>           STFT mode only. Number of output bands (required in stft-analysis)
+  --delete-current          STFT mode only. Drop current table before processing
+  --recursive               STFT mode only. Scan files recursively from input-dir
+  --stft-proc-threads <n>   STFT mode only. Processing threads per file (default: 1)
+  --peak-proc-threads <n>   Peak mode only. Processing threads per song (default: 1)
+  --stft-file-threads <n>   STFT mode only. Number of files analyzed in parallel (default: 1)
+  --peak-file-threads <n>   Peak mode only. Number of songs analyzed in parallel (default: 1)
+  --insert-queue-size <n>   Bounded queue size between analyze and DB insert (default: 1024)
+  --ffmpeg-path <path>      ffmpeg executable path or directory containing ffmpeg/ffprobe
+  --show-progress           Show advanced progress UI on interactive stderr
+  --help, -h                Show help
+
+Examples:
+  SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --mode peak-analysis --stems Piano,Drums --peak-file-threads 2 --peak-proc-threads 4 --insert-queue-size 2048 --show-progress
+  SoundAnalyzer.Cli.exe --window-size 2048samples --hop 512samples --target-sampling 44100hz --input-dir /path/to/dir --db-file /path/to/file.db --mode stft-analysis --bin-count 12 --stft-file-threads 2 --stft-proc-threads 6 --insert-queue-size 4096 --show-progress

--- a/build-logs/2026-02-24T204718-progress-bar-fix-help-audiosplitter.txt
+++ b/build-logs/2026-02-24T204718-progress-bar-fix-help-audiosplitter.txt
@@ -1,0 +1,19 @@
+Usage:
+  AudioSplitter.Cli.exe (--input-file <path> | --input-dir <path>) --output-dir <path> --level <dBFS> --duration <time> [options]
+
+Required options:
+  --input-file <path>       Input audio file path (wav/flac/m4a/caf)
+  --input-dir <path>        Input directory path
+  --output-dir <path>       Output directory path
+  --level <dBFS>            Silence threshold in dBFS, negative value only
+  --duration <time>         Silence duration threshold (e.g. 2000ms, 2s, 1m)
+
+Optional:
+  --recursive               Scan input directory recursively (available with --input-dir)
+  --after-offset <time>     Keep this duration from silence start in previous segment (default: 0ms)
+  --resume-offset <time>    Offset from next sound start for next segment, negative allowed (default: 0ms)
+  --resolution-type <spec>  Output resolution: 16bit|24bit|32float,<rate>hz
+  --ffmpeg-path <path>      ffmpeg executable path or directory containing ffmpeg/ffprobe
+  --progress                Show two-line progress bars on interactive stderr
+  -y                        Overwrite output without confirmation
+  --help, -h                Show help

--- a/build-logs/2026-02-24T204828-progress-bar-fix-build3.txt
+++ b/build-logs/2026-02-24T204828-progress-bar-fix-build3.txt
@@ -1,0 +1,22 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+
+ビルドに成功しました。
+    0 個の警告
+    0 エラー
+
+経過時間 00:00:03.34

--- a/build-logs/2026-02-24T204924-progress-bar-fix-test2.txt
+++ b/build-logs/2026-02-24T204924-progress-bar-fix-test2.txt
@@ -1,0 +1,65 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+VSTest のバージョン 18.0.1 (x64)
+
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+テスト実行を開始しています。お待ちください...
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+
+成功!   -失敗:     0、合格:    13、スキップ:     0、合計:    13、期間: 153 ms - Cli.Shared.Tests.dll (net10.0)
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+
+成功!   -失敗:     0、合格:    12、スキップ:     0、合計:    12、期間: 185 ms - AudioProcessor.Tests.dll (net10.0)
+VSTest のバージョン 18.0.1 (x64)
+
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+VSTest のバージョン 18.0.1 (x64)
+
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+VSTest のバージョン 18.0.1 (x64)
+
+
+成功!   -失敗:     0、合格:     8、スキップ:     0、合計:     8、期間: 105 ms - AudioSplitter.Core.Tests.dll (net10.0)
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:     7、スキップ:     0、合計:     7、期間: 165 ms - STFTAnalyzer.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:     5、スキップ:     0、合計:     5、期間: 144 ms - PeakAnalyzer.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    15、スキップ:     0、合計:    15、期間: 309 ms - AudioSplitter.Cli.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    43、スキップ:     0、合計:    43、期間: 1 s - SoundAnalyzer.Cli.Tests.dll (net10.0)

--- a/build-logs/2026-02-24T211205-merged-progress-build.txt
+++ b/build-logs/2026-02-24T211205-merged-progress-build.txt
@@ -1,0 +1,35 @@
+  復元対象のプロジェクトを決定しています...
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\AudioSplitter.Core.Tests.csproj を復元しました (2.49 秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\STFTAnalyzer.Core.csproj を復元しました (2.49 秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\STFTAnalyzer.Core.Tests.csproj を復元しました (2.49 秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\PeakAnalyzer.Core.csproj を復元しました (2.49 秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\Cli.Shared.Tests.csproj を復元しました (2.49 秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\AudioSplitter.Cli.csproj を復元しました (2.49 秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\SoundAnalyzer.Cli.Tests.csproj を復元しました (2.49 秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\AudioProcessor.csproj を復元しました (2.49 秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\AudioProcessor.Tests.csproj を復元しました (2.49 秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\Cli.Shared.csproj を復元しました (2.49 秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\SoundAnalyzer.Cli.csproj を復元しました (2.49 秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\PeakAnalyzer.Core.Tests.csproj を復元しました (2.49 秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\AudioSplitter.Core.csproj を復元しました (2.49 秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\AudioSplitter.Cli.Tests.csproj を復元しました (2.49 秒)。
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+
+ビルドに成功しました。
+    0 個の警告
+    0 エラー
+
+経過時間 00:00:17.58

--- a/build-logs/2026-02-24T211230-merged-progress-test.txt
+++ b/build-logs/2026-02-24T211230-merged-progress-test.txt
@@ -1,0 +1,65 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:    12、スキップ:     0、合計:    12、期間: 87 ms - AudioProcessor.Tests.dll (net10.0)
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+VSTest のバージョン 18.0.1 (x64)
+
+
+テスト実行を開始しています。お待ちください...
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:    13、スキップ:     0、合計:    13、期間: 723 ms - Cli.Shared.Tests.dll (net10.0)
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:     7、スキップ:     0、合計:     7、期間: 1 s - STFTAnalyzer.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:     5、スキップ:     0、合計:     5、期間: 617 ms - PeakAnalyzer.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:     8、スキップ:     0、合計:     8、期間: 713 ms - AudioSplitter.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    15、スキップ:     0、合計:    15、期間: 832 ms - AudioSplitter.Cli.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    52、スキップ:     0、合計:    52、期間: 1 s - SoundAnalyzer.Cli.Tests.dll (net10.0)

--- a/build-logs/2026-02-24T211246-merged-progress-help-soundanalyzer.txt
+++ b/build-logs/2026-02-24T211246-merged-progress-help-soundanalyzer.txt
@@ -1,0 +1,32 @@
+Usage:
+  SoundAnalyzer.Cli.exe --window-size <len> --hop <len> --input-dir <path> --db-file <path> --mode <peak-analysis|stft-analysis> [options]
+
+Required options:
+  --window-size <len>       Analysis window size (ms/s/m/sample/samples)
+  --hop <len>               Hop size (ms/s/m/sample/samples)
+  --input-dir <path>        Input root directory
+  --db-file <path>          SQLite db file path
+  --mode <value>            peak-analysis or stft-analysis
+
+Optional:
+  --target-sampling <n>hz   Required when window/hop uses sample(s) in stft mode
+  --stems <csv>             Peak mode only. Stem names to analyze (case-insensitive)
+  --table-name-override <n> Override table name (default: peak=T_PeakAnalysis, stft=T_STFTAnalysis)
+  --upsert                  Upsert by unique key
+  --skip-duplicate          Skip duplicates by unique key
+  --min-limit-db <dB>       Clamp lower dB bound for all windows/bins (default: -120.0)
+  --bin-count <n>           STFT mode only. Number of output bands (required in stft-analysis)
+  --delete-current          STFT mode only. Drop current table before processing
+  --recursive               STFT mode only. Scan files recursively from input-dir
+  --stft-proc-threads <n>   STFT mode only. Processing threads per file (default: 1)
+  --peak-proc-threads <n>   Peak mode only. Processing threads per song (default: 1)
+  --stft-file-threads <n>   STFT mode only. Number of files analyzed in parallel (default: 1)
+  --peak-file-threads <n>   Peak mode only. Number of songs analyzed in parallel (default: 1)
+  --insert-queue-size <n>   Bounded queue size between analyze and DB insert (default: 1024)
+  --ffmpeg-path <path>      ffmpeg executable path or directory containing ffmpeg/ffprobe
+  --show-progress           Show advanced progress UI on interactive stderr
+  --help, -h                Show help
+
+Examples:
+  SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --mode peak-analysis --stems Piano,Drums --peak-file-threads 2 --peak-proc-threads 4 --insert-queue-size 2048 --show-progress
+  SoundAnalyzer.Cli.exe --window-size 2048samples --hop 512samples --target-sampling 44100hz --input-dir /path/to/dir --db-file /path/to/file.db --mode stft-analysis --bin-count 12 --stft-file-threads 2 --stft-proc-threads 6 --insert-queue-size 4096 --show-progress

--- a/build-logs/2026-02-24T211300-merged-progress-help-audiosplitter.txt
+++ b/build-logs/2026-02-24T211300-merged-progress-help-audiosplitter.txt
@@ -1,0 +1,19 @@
+Usage:
+  AudioSplitter.Cli.exe (--input-file <path> | --input-dir <path>) --output-dir <path> --level <dBFS> --duration <time> [options]
+
+Required options:
+  --input-file <path>       Input audio file path (wav/flac/m4a/caf)
+  --input-dir <path>        Input directory path
+  --output-dir <path>       Output directory path
+  --level <dBFS>            Silence threshold in dBFS, negative value only
+  --duration <time>         Silence duration threshold (e.g. 2000ms, 2s, 1m)
+
+Optional:
+  --recursive               Scan input directory recursively (available with --input-dir)
+  --after-offset <time>     Keep this duration from silence start in previous segment (default: 0ms)
+  --resume-offset <time>    Offset from next sound start for next segment, negative allowed (default: 0ms)
+  --resolution-type <spec>  Output resolution: 16bit|24bit|32float,<rate>hz
+  --ffmpeg-path <path>      ffmpeg executable path or directory containing ffmpeg/ffprobe
+  --progress                Show two-line progress bars on interactive stderr
+  -y                        Overwrite output without confirmation
+  --help, -h                Show help

--- a/build-logs/2026-02-24T214903-progress-cursor-fix-build2.txt
+++ b/build-logs/2026-02-24T214903-progress-cursor-fix-build2.txt
@@ -1,0 +1,22 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+
+ビルドに成功しました。
+    0 個の警告
+    0 エラー
+
+経過時間 00:00:03.25

--- a/build-logs/2026-02-24T214914-progress-cursor-fix-test.txt
+++ b/build-logs/2026-02-24T214914-progress-cursor-fix-test.txt
@@ -1,0 +1,65 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+VSTest のバージョン 18.0.1 (x64)
+
+C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+テスト実行を開始しています。お待ちください...
+VSTest のバージョン 18.0.1 (x64)
+
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+テスト実行を開始しています。お待ちください...
+
+成功!   -失敗:     0、合格:    12、スキップ:     0、合計:    12、期間: 150 ms - AudioProcessor.Tests.dll (net10.0)
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:    13、スキップ:     0、合計:    13、期間: 766 ms - Cli.Shared.Tests.dll (net10.0)
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+VSTest のバージョン 18.0.1 (x64)
+
+C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:     7、スキップ:     0、合計:     7、期間: 936 ms - STFTAnalyzer.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:     5、スキップ:     0、合計:     5、期間: 732 ms - PeakAnalyzer.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:     8、スキップ:     0、合計:     8、期間: 736 ms - AudioSplitter.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    15、スキップ:     0、合計:    15、期間: 1 s - AudioSplitter.Cli.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    52、スキップ:     0、合計:    52、期間: 2 s - SoundAnalyzer.Cli.Tests.dll (net10.0)

--- a/build-logs/2026-02-24T214935-progress-cursor-fix-help-audiosplitter.txt
+++ b/build-logs/2026-02-24T214935-progress-cursor-fix-help-audiosplitter.txt
@@ -1,0 +1,19 @@
+Usage:
+  AudioSplitter.Cli.exe (--input-file <path> | --input-dir <path>) --output-dir <path> --level <dBFS> --duration <time> [options]
+
+Required options:
+  --input-file <path>       Input audio file path (wav/flac/m4a/caf)
+  --input-dir <path>        Input directory path
+  --output-dir <path>       Output directory path
+  --level <dBFS>            Silence threshold in dBFS, negative value only
+  --duration <time>         Silence duration threshold (e.g. 2000ms, 2s, 1m)
+
+Optional:
+  --recursive               Scan input directory recursively (available with --input-dir)
+  --after-offset <time>     Keep this duration from silence start in previous segment (default: 0ms)
+  --resume-offset <time>    Offset from next sound start for next segment, negative allowed (default: 0ms)
+  --resolution-type <spec>  Output resolution: 16bit|24bit|32float,<rate>hz
+  --ffmpeg-path <path>      ffmpeg executable path or directory containing ffmpeg/ffprobe
+  --progress                Show two-line progress bars on interactive stderr
+  -y                        Overwrite output without confirmation
+  --help, -h                Show help

--- a/build-logs/2026-02-24T214935-progress-cursor-fix-help-soundanalyzer.txt
+++ b/build-logs/2026-02-24T214935-progress-cursor-fix-help-soundanalyzer.txt
@@ -1,0 +1,32 @@
+Usage:
+  SoundAnalyzer.Cli.exe --window-size <len> --hop <len> --input-dir <path> --db-file <path> --mode <peak-analysis|stft-analysis> [options]
+
+Required options:
+  --window-size <len>       Analysis window size (ms/s/m/sample/samples)
+  --hop <len>               Hop size (ms/s/m/sample/samples)
+  --input-dir <path>        Input root directory
+  --db-file <path>          SQLite db file path
+  --mode <value>            peak-analysis or stft-analysis
+
+Optional:
+  --target-sampling <n>hz   Required when window/hop uses sample(s) in stft mode
+  --stems <csv>             Peak mode only. Stem names to analyze (case-insensitive)
+  --table-name-override <n> Override table name (default: peak=T_PeakAnalysis, stft=T_STFTAnalysis)
+  --upsert                  Upsert by unique key
+  --skip-duplicate          Skip duplicates by unique key
+  --min-limit-db <dB>       Clamp lower dB bound for all windows/bins (default: -120.0)
+  --bin-count <n>           STFT mode only. Number of output bands (required in stft-analysis)
+  --delete-current          STFT mode only. Drop current table before processing
+  --recursive               STFT mode only. Scan files recursively from input-dir
+  --stft-proc-threads <n>   STFT mode only. Processing threads per file (default: 1)
+  --peak-proc-threads <n>   Peak mode only. Processing threads per song (default: 1)
+  --stft-file-threads <n>   STFT mode only. Number of files analyzed in parallel (default: 1)
+  --peak-file-threads <n>   Peak mode only. Number of songs analyzed in parallel (default: 1)
+  --insert-queue-size <n>   Bounded queue size between analyze and DB insert (default: 1024)
+  --ffmpeg-path <path>      ffmpeg executable path or directory containing ffmpeg/ffprobe
+  --show-progress           Show advanced progress UI on interactive stderr
+  --help, -h                Show help
+
+Examples:
+  SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --mode peak-analysis --stems Piano,Drums --peak-file-threads 2 --peak-proc-threads 4 --insert-queue-size 2048 --show-progress
+  SoundAnalyzer.Cli.exe --window-size 2048samples --hop 512samples --target-sampling 44100hz --input-dir /path/to/dir --db-file /path/to/file.db --mode stft-analysis --bin-count 12 --stft-file-threads 2 --stft-proc-threads 6 --insert-queue-size 4096 --show-progress

--- a/build-logs/2026-02-24T223940-cli-shared-refactor-build3.txt
+++ b/build-logs/2026-02-24T223940-cli-shared-refactor-build3.txt
@@ -1,0 +1,22 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+
+ビルドに成功しました。
+    0 個の警告
+    0 エラー
+
+経過時間 00:00:02.43

--- a/build-logs/2026-02-24T223950-cli-shared-refactor-test.txt
+++ b/build-logs/2026-02-24T223950-cli-shared-refactor-test.txt
@@ -1,0 +1,65 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+テスト実行を開始しています。お待ちください...
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+VSTest のバージョン 18.0.1 (x64)
+
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+VSTest のバージョン 18.0.1 (x64)
+
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:    12、スキップ:     0、合計:    12、期間: 104 ms - AudioProcessor.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    21、スキップ:     0、合計:    21、期間: 912 ms - Cli.Shared.Tests.dll (net10.0)
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+テスト実行を開始しています。お待ちください...
+
+成功!   -失敗:     0、合格:     8、スキップ:     0、合計:     8、期間: 741 ms - AudioSplitter.Core.Tests.dll (net10.0)
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:     7、スキップ:     0、合計:     7、期間: 652 ms - STFTAnalyzer.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:     5、スキップ:     0、合計:     5、期間: 610 ms - PeakAnalyzer.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    15、スキップ:     0、合計:    15、期間: 1 s - AudioSplitter.Cli.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    54、スキップ:     0、合計:    54、期間: 1 s - SoundAnalyzer.Cli.Tests.dll (net10.0)

--- a/build-logs/2026-02-24T224015-cli-shared-refactor-help-audiosplitter.txt
+++ b/build-logs/2026-02-24T224015-cli-shared-refactor-help-audiosplitter.txt
@@ -1,0 +1,19 @@
+Usage:
+  AudioSplitter.Cli.exe (--input-file <path> | --input-dir <path>) --output-dir <path> --level <dBFS> --duration <time> [options]
+
+Required options:
+  --input-file <path>       Input audio file path (wav/flac/m4a/caf)
+  --input-dir <path>        Input directory path
+  --output-dir <path>       Output directory path
+  --level <dBFS>            Silence threshold in dBFS, negative value only
+  --duration <time>         Silence duration threshold (e.g. 2000ms, 2s, 1m)
+
+Optional:
+  --recursive               Scan input directory recursively (available with --input-dir)
+  --after-offset <time>     Keep this duration from silence start in previous segment (default: 0ms)
+  --resume-offset <time>    Offset from next sound start for next segment, negative allowed (default: 0ms)
+  --resolution-type <spec>  Output resolution: 16bit|24bit|32float,<rate>hz
+  --ffmpeg-path <path>      ffmpeg executable path or directory containing ffmpeg/ffprobe
+  --progress                Show two-line progress bars on interactive stderr
+  -y                        Overwrite output without confirmation
+  --help, -h                Show help

--- a/build-logs/2026-02-24T224015-cli-shared-refactor-help-soundanalyzer.txt
+++ b/build-logs/2026-02-24T224015-cli-shared-refactor-help-soundanalyzer.txt
@@ -1,0 +1,32 @@
+Usage:
+  SoundAnalyzer.Cli.exe --window-size <len> --hop <len> --input-dir <path> --db-file <path> --mode <peak-analysis|stft-analysis> [options]
+
+Required options:
+  --window-size <len>       Analysis window size (ms/s/m/sample/samples)
+  --hop <len>               Hop size (ms/s/m/sample/samples)
+  --input-dir <path>        Input root directory
+  --db-file <path>          SQLite db file path
+  --mode <value>            peak-analysis or stft-analysis
+
+Optional:
+  --target-sampling <n>hz   Required when window/hop uses sample(s) in stft mode
+  --stems <csv>             Peak mode only. Stem names to analyze (case-insensitive)
+  --table-name-override <n> Override table name (default: peak=T_PeakAnalysis, stft=T_STFTAnalysis)
+  --upsert                  Upsert by unique key
+  --skip-duplicate          Skip duplicates by unique key
+  --min-limit-db <dB>       Clamp lower dB bound for all windows/bins (default: -120.0)
+  --bin-count <n>           STFT mode only. Number of output bands (required in stft-analysis)
+  --delete-current          STFT mode only. Drop current table before processing
+  --recursive               STFT mode only. Scan files recursively from input-dir
+  --stft-proc-threads <n>   STFT mode only. Processing threads per file (default: 1)
+  --peak-proc-threads <n>   Peak mode only. Processing threads per song (default: 1)
+  --stft-file-threads <n>   STFT mode only. Number of files analyzed in parallel (default: 1)
+  --peak-file-threads <n>   Peak mode only. Number of songs analyzed in parallel (default: 1)
+  --insert-queue-size <n>   Bounded queue size between analyze and DB insert (default: 1024)
+  --ffmpeg-path <path>      ffmpeg executable path or directory containing ffmpeg/ffprobe
+  --show-progress           Show advanced progress UI on interactive stderr
+  --help, -h                Show help
+
+Examples:
+  SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --mode peak-analysis --stems Piano,Drums --peak-file-threads 2 --peak-proc-threads 4 --insert-queue-size 2048 --show-progress
+  SoundAnalyzer.Cli.exe --window-size 2048samples --hop 512samples --target-sampling 44100hz --input-dir /path/to/dir --db-file /path/to/file.db --mode stft-analysis --bin-count 12 --stft-file-threads 2 --stft-proc-threads 6 --insert-queue-size 4096 --show-progress

--- a/build-logs/2026-02-24T224036-cli-shared-refactor-publish-soundanalyzer.txt
+++ b/build-logs/2026-02-24T224036-cli-shared-refactor-publish-soundanalyzer.txt
@@ -1,0 +1,12 @@
+  復元対象のプロジェクトを決定しています...
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\STFTAnalyzer.Core.csproj を復元しました (639 ミリ秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\AudioProcessor.csproj を復元しました (639 ミリ秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\Cli.Shared.csproj を復元しました (639 ミリ秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\PeakAnalyzer.Core.csproj を復元しました (639 ミリ秒)。
+  C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\SoundAnalyzer.Cli.csproj を復元しました (655 ミリ秒)。
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Release\net10.0\win-x64\Cli.Shared.dll
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Release\net10.0\win-x64\AudioProcessor.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Release\net10.0\win-x64\STFTAnalyzer.Core.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Release\net10.0\win-x64\PeakAnalyzer.Core.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Release\net10.0\win-x64\SoundAnalyzer.Cli.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Release\net10.0\win-x64\publish\


### PR DESCRIPTION
## Background
SoundAnalyzer.Cli had synchronous analyze + DB insert coupling, so DB wait could directly stall analysis throughput.

## What changed
- Added new CLI options:
  - `--stft-proc-threads`
  - `--peak-proc-threads`
  - `--stft-file-threads`
  - `--peak-file-threads`
  - `--insert-queue-size`
  - `--show-progress`
- Replaced `--progress` with `--show-progress` (breaking change)
- Changed mode-incompatible options from hard error to warning-and-ignore
  - warnings are emitted as stderr JSON (`{"Warnings":[...]}`)
- Refactored batch execution for peak/stft:
  - bounded analyze->insert queue
  - single DB insert consumer
  - producer backpressure when queue is full
  - parallel file/song workers and mode-specific proc threads
- Added advanced SoundAnalyzer progress UI:
  - songs completion, thread activity circles, queue occupancy, per-thread song/analyze/insert status
  - ANSI + fallback behavior in interactive stderr
- Added STFT processing thread propagation:
  - `StftAnalysisRequest.ProcessingThreads`
  - `StftWindowAnalyzer` mode switch (`proc<=ch`: channel parallel, `proc>ch`: window pipeline)
- Updated docs (`README.md`, `SoundAnalyzer.Cli/README.md`, `Cli.Shared/README.md`)
- Added/updated tests for parser behavior and STFT processing-thread behavior

## Compatibility
- Breaking: `--progress` is no longer accepted by SoundAnalyzer.Cli.
- Use `--show-progress` instead.

## Verification
- `dotnet build AudioProcessor.slnx -warnaserror`
- `dotnet test AudioProcessor.slnx`
- `dotnet run --project SoundAnalyzer.Cli -- --help`
- `dotnet run --project AudioSplitter.Cli -- --help`

Logs:
- `build-logs/2026-02-24T203408-issue17-thread-queue-build.txt`
- `build-logs/2026-02-24T203408-issue17-thread-queue-test.txt`
- `build-logs/2026-02-24T203408-issue17-thread-queue-soundanalyzer-help.txt`
- `build-logs/2026-02-24T203408-issue17-thread-queue-audiosplitter-help.txt`

Closes #17
