### PR TITLE
Improve SQLite bulk insert throughput in SoundAnalyzer.Cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ AudioProcessor は、オーディオ解析・変換ツール群を提供する .
   - `sample(s)` を1つでも使う場合は `--target-sampling <n>hz` が必須
   - STFT bin は `bin_no` / `db` の縦持ち行として保存（列数上限依存を回避）
   - `--stft-proc-threads` / `--stft-file-threads` / `--insert-queue-size` で並列・キュー制御
+  - 大量投入向けに `--sqlite-batch-row-count`（既定 `512`）で複数行 INSERT バッチサイズを調整可能
+  - `--sqlite-fast-mode` 指定時のみ SQLite 書込PRAGMAを速度優先へ切替（耐障害性トレードオフあり）
 - `--show-progress` は interactive な `pwsh/cmd` で、Songs/Threads/Queue の詳細進捗を `stderr` に表示（Thread行は単一ゲージで Insert=緑 / Analyze=白 / 未処理=斑点）
 
 ## プロジェクト構成
@@ -40,6 +42,9 @@ AudioProcessor は、オーディオ解析・変換ツール群を提供する .
 
 `SoundAnalyzer.Cli` の SQLite 保存は、初期化時に `journal_mode=WAL` を試行します。  
 WAL 非対応環境では既存ジャーナルモードへ自動フォールバックします。
+
+`--sqlite-fast-mode` 指定時は `synchronous=OFF` など速度優先PRAGMAを追加で適用します。  
+異常終了時の破損/欠損リスクが上がるため、投入ジョブ専用DB・バックアップ運用を推奨します。
 
 ## 前提環境
 

--- a/SoundAnalyzer.Cli.Tests/Presentation/Cli/Arguments/CommandLineParserTests.cs
+++ b/SoundAnalyzer.Cli.Tests/Presentation/Cli/Arguments/CommandLineParserTests.cs
@@ -352,6 +352,8 @@ public sealed class CommandLineParserTests
         Assert.Equal(1, result.Arguments.StftFileThreads);
         Assert.Equal(1, result.Arguments.PeakFileThreads);
         Assert.Equal(1024, result.Arguments.InsertQueueSize);
+        Assert.False(result.Arguments.SqliteFastMode);
+        Assert.Equal(512, result.Arguments.SqliteBatchRowCount);
     }
 
     [Fact]
@@ -365,6 +367,8 @@ public sealed class CommandLineParserTests
             "--stft-file-threads", "3",
             "--peak-file-threads", "2",
             "--insert-queue-size", "4096",
+            "--sqlite-fast-mode",
+            "--sqlite-batch-row-count", "256",
         ];
 
         CommandLineParseResult result = CommandLineParser.Parse(args);
@@ -376,5 +380,58 @@ public sealed class CommandLineParserTests
         Assert.Equal(3, result.Arguments.StftFileThreads);
         Assert.Equal(2, result.Arguments.PeakFileThreads);
         Assert.Equal(4096, result.Arguments.InsertQueueSize);
+        Assert.True(result.Arguments.SqliteFastMode);
+        Assert.Equal(256, result.Arguments.SqliteBatchRowCount);
+    }
+
+    [Fact]
+    public void Parse_ShouldFail_WhenSqliteBatchRowCountIsInvalid()
+    {
+        string[] args =
+        [
+            .. BaseStftArgs,
+            "--sqlite-batch-row-count", "0",
+        ];
+
+        CommandLineParseResult result = CommandLineParser.Parse(args);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            result.Errors,
+            error => error.Contains("Invalid integer value", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Parse_ShouldFail_WhenSqliteBatchRowCountIsNegative()
+    {
+        string[] args =
+        [
+            .. BaseStftArgs,
+            "--sqlite-batch-row-count", "-10",
+        ];
+
+        CommandLineParseResult result = CommandLineParser.Parse(args);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            result.Errors,
+            error => error.Contains("Invalid integer value", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Parse_ShouldFail_WhenSqliteBatchRowCountIsNotNumeric()
+    {
+        string[] args =
+        [
+            .. BaseStftArgs,
+            "--sqlite-batch-row-count", "abc",
+        ];
+
+        CommandLineParseResult result = CommandLineParser.Parse(args);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            result.Errors,
+            error => error.Contains("Invalid integer value", StringComparison.Ordinal));
     }
 }

--- a/SoundAnalyzer.Cli/Infrastructure/Execution/PeakAnalysisBatchExecutor.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Execution/PeakAnalysisBatchExecutor.cs
@@ -53,6 +53,7 @@ internal sealed class PeakAnalysisBatchExecutor
             arguments.Stems);
         List<SongBatch> songs = BuildSongBatches(resolved.Files);
         SqliteConflictMode conflictMode = BatchExecutionSupport.ResolveConflictMode(arguments);
+        SqliteWriteOptions writeOptions = new(arguments.SqliteFastMode, arguments.SqliteBatchRowCount);
 
         using SoundAnalyzerProgressTracker progressTracker = SoundAnalyzerProgressTracker.Create(
             arguments.ShowProgress,
@@ -62,7 +63,7 @@ internal sealed class PeakAnalysisBatchExecutor
             arguments.PeakFileThreads,
             arguments.InsertQueueSize);
 
-        using SqlitePeakAnalysisStore store = new(arguments.DbFilePath, arguments.TableName, conflictMode);
+        using SqlitePeakAnalysisStore store = new(arguments.DbFilePath, arguments.TableName, conflictMode, writeOptions);
         store.Initialize();
 
         FfmpegToolPaths? progressProbeToolPaths = null;

--- a/SoundAnalyzer.Cli/Infrastructure/Execution/StftAnalysisBatchExecutor.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Execution/StftAnalysisBatchExecutor.cs
@@ -63,13 +63,15 @@ internal sealed class StftAnalysisBatchExecutor
             arguments.InsertQueueSize);
 
         SqliteConflictMode conflictMode = BatchExecutionSupport.ResolveConflictMode(arguments);
+        SqliteWriteOptions writeOptions = new(arguments.SqliteFastMode, arguments.SqliteBatchRowCount);
         using SqliteStftAnalysisStore store = new(
             arguments.DbFilePath,
             arguments.TableName,
             anchorColumnName,
             conflictMode,
             binCount,
-            arguments.DeleteCurrent);
+            arguments.DeleteCurrent,
+            writeOptions);
         store.Initialize();
 
         FfmpegToolPaths toolPaths = ffmpegLocator.Resolve(arguments.FfmpegPath);

--- a/SoundAnalyzer.Cli/Infrastructure/Sqlite/SqliteBatchSizeCalculator.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Sqlite/SqliteBatchSizeCalculator.cs
@@ -1,0 +1,56 @@
+using System.Globalization;
+using Microsoft.Data.Sqlite;
+
+namespace SoundAnalyzer.Cli.Infrastructure.Sqlite;
+
+internal static class SqliteBatchSizeCalculator
+{
+    private const int DefaultMaxVariableNumber = 999;
+    private const string MaxVariableNumberPrefix = "MAX_VARIABLE_NUMBER=";
+
+    public static int ResolveEffectiveBatchRowCount(
+        SqliteConnection connection,
+        int requestedBatchRowCount,
+        int columnsPerRow)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(requestedBatchRowCount);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(columnsPerRow);
+
+        int maxVariables = ReadMaxVariableNumber(connection);
+        int maxRowsByVariableLimit = Math.Max(1, maxVariables / columnsPerRow);
+        return Math.Min(requestedBatchRowCount, maxRowsByVariableLimit);
+    }
+
+    private static int ReadMaxVariableNumber(SqliteConnection connection)
+    {
+        try
+        {
+            using SqliteCommand command = connection.CreateCommand();
+            command.CommandText = "PRAGMA compile_options;";
+
+            using SqliteDataReader reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                string option = reader.GetString(0);
+                if (!option.StartsWith(MaxVariableNumberPrefix, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                string value = option[MaxVariableNumberPrefix.Length..];
+                if (int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out int parsed)
+                    && parsed > 0)
+                {
+                    return parsed;
+                }
+            }
+        }
+        catch (SqliteException)
+        {
+            // Fallback for environments that do not expose compile options.
+        }
+
+        return DefaultMaxVariableNumber;
+    }
+}

--- a/SoundAnalyzer.Cli/Infrastructure/Sqlite/SqliteJournalModeConfigurator.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Sqlite/SqliteJournalModeConfigurator.cs
@@ -2,8 +2,25 @@ using Microsoft.Data.Sqlite;
 
 namespace SoundAnalyzer.Cli.Infrastructure.Sqlite;
 
+#pragma warning disable CA2100
 internal static class SqliteJournalModeConfigurator
 {
+    public static string Configure(SqliteConnection connection, bool fastMode)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+
+        string mode = TryEnableWal(connection);
+        if (fastMode)
+        {
+            TryExecutePragma(connection, SqliteFastPragma.SynchronousOff);
+            TryExecutePragma(connection, SqliteFastPragma.LockingExclusive);
+            TryExecutePragma(connection, SqliteFastPragma.TempStoreMemory);
+            TryExecutePragma(connection, SqliteFastPragma.CacheSizeLarge);
+        }
+
+        return mode;
+    }
+
     public static string TryEnableWal(SqliteConnection connection)
     {
         ArgumentNullException.ThrowIfNull(connection);
@@ -29,4 +46,36 @@ internal static class SqliteJournalModeConfigurator
         object? fallbackScalar = fallbackCommand.ExecuteScalar();
         return fallbackScalar as string ?? string.Empty;
     }
+
+    private static void TryExecutePragma(SqliteConnection connection, SqliteFastPragma pragma)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+
+        try
+        {
+            using SqliteCommand command = connection.CreateCommand();
+            command.CommandText = pragma switch
+            {
+                SqliteFastPragma.SynchronousOff => "PRAGMA synchronous=OFF;",
+                SqliteFastPragma.LockingExclusive => "PRAGMA locking_mode=EXCLUSIVE;",
+                SqliteFastPragma.TempStoreMemory => "PRAGMA temp_store=MEMORY;",
+                SqliteFastPragma.CacheSizeLarge => "PRAGMA cache_size=-262144;",
+                _ => throw new ArgumentOutOfRangeException(nameof(pragma)),
+            };
+            _ = command.ExecuteNonQuery();
+        }
+        catch (SqliteException)
+        {
+            // Best-effort tuning.
+        }
+    }
+
+    private enum SqliteFastPragma
+    {
+        SynchronousOff = 0,
+        LockingExclusive,
+        TempStoreMemory,
+        CacheSizeLarge,
+    }
 }
+#pragma warning restore CA2100

--- a/SoundAnalyzer.Cli/Infrastructure/Sqlite/SqlitePeakAnalysisStore.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Sqlite/SqlitePeakAnalysisStore.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text;
 using Microsoft.Data.Sqlite;
 using PeakAnalyzer.Core.Application.Ports;
 using PeakAnalyzer.Core.Domain.Models;
@@ -8,16 +9,26 @@ namespace SoundAnalyzer.Cli.Infrastructure.Sqlite;
 #pragma warning disable CA2100
 internal sealed class SqlitePeakAnalysisStore : IPeakAnalysisPointWriter, IDisposable
 {
+    private const int InsertColumnCount = 7;
+
     private readonly string dbFilePath;
     private readonly string tableName;
     private readonly SqliteConflictMode conflictMode;
+    private readonly SqliteWriteOptions writeOptions;
+    private readonly List<PeakInsertRow> pendingRows = new();
 
     private SqliteConnection? connection;
     private SqliteTransaction? transaction;
-    private SqliteCommand? insertCommand;
     private bool completed;
+    private bool deferIndexCreation;
+    private bool indexesCreated;
+    private int effectiveBatchRowCount;
 
-    public SqlitePeakAnalysisStore(string dbFilePath, string tableName, SqliteConflictMode conflictMode)
+    public SqlitePeakAnalysisStore(
+        string dbFilePath,
+        string tableName,
+        SqliteConflictMode conflictMode,
+        SqliteWriteOptions? writeOptions = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(dbFilePath);
         ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
@@ -25,6 +36,7 @@ internal sealed class SqlitePeakAnalysisStore : IPeakAnalysisPointWriter, IDispo
         this.dbFilePath = dbFilePath;
         this.tableName = tableName;
         this.conflictMode = conflictMode;
+        this.writeOptions = writeOptions ?? SqliteWriteOptions.Default;
     }
 
     public void Initialize()
@@ -36,33 +48,46 @@ internal sealed class SqlitePeakAnalysisStore : IPeakAnalysisPointWriter, IDispo
 
         connection = new SqliteConnection(BuildConnectionString(dbFilePath));
         connection.Open();
-        _ = SqliteJournalModeConfigurator.TryEnableWal(connection);
+        _ = SqliteJournalModeConfigurator.Configure(connection, writeOptions.FastMode);
+        effectiveBatchRowCount = SqliteBatchSizeCalculator.ResolveEffectiveBatchRowCount(
+            connection,
+            writeOptions.BatchRowCount,
+            InsertColumnCount);
+
+        bool tableExists = TableExists(connection, tableName);
 
         transaction = connection.BeginTransaction();
         CreateTableIfNeeded(connection, transaction, tableName);
-        CreateIndexesIfNeeded(connection, transaction, tableName);
 
-        insertCommand = BuildInsertCommand(connection, transaction, tableName, conflictMode);
+        deferIndexCreation = !tableExists && conflictMode == SqliteConflictMode.Error;
+        if (!deferIndexCreation)
+        {
+            CreateIndexesIfNeeded(connection, transaction, tableName);
+            indexesCreated = true;
+        }
     }
 
     public void Write(PeakAnalysisPoint point)
     {
         ArgumentNullException.ThrowIfNull(point);
 
-        SqliteCommand command = insertCommand
-            ?? throw new InvalidOperationException("SqlitePeakAnalysisStore is not initialized.");
+        _ = connection ?? throw new InvalidOperationException("SqlitePeakAnalysisStore is not initialized.");
+        _ = transaction ?? throw new InvalidOperationException("SqlitePeakAnalysisStore is not initialized.");
 
         long nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        pendingRows.Add(new PeakInsertRow(
+            point.Name,
+            point.Stem,
+            point.WindowMs,
+            point.Ms,
+            point.Db,
+            nowMs,
+            nowMs));
 
-        command.Parameters["$name"].Value = point.Name;
-        command.Parameters["$stem"].Value = point.Stem;
-        command.Parameters["$window"].Value = point.WindowMs;
-        command.Parameters["$ms"].Value = point.Ms;
-        command.Parameters["$db"].Value = point.Db;
-        command.Parameters["$createAt"].Value = nowMs;
-        command.Parameters["$modifiedAt"].Value = nowMs;
-
-        _ = command.ExecuteNonQuery();
+        if (pendingRows.Count >= effectiveBatchRowCount)
+        {
+            FlushPendingRows();
+        }
     }
 
     public void Complete()
@@ -71,6 +96,16 @@ internal sealed class SqlitePeakAnalysisStore : IPeakAnalysisPointWriter, IDispo
         if (currentTransaction is null)
         {
             return;
+        }
+
+        FlushPendingRows();
+
+        if (deferIndexCreation && !indexesCreated)
+        {
+            SqliteConnection currentConnection = connection
+                ?? throw new InvalidOperationException("SqlitePeakAnalysisStore is not initialized.");
+            CreateIndexesIfNeeded(currentConnection, currentTransaction, tableName);
+            indexesCreated = true;
         }
 
         currentTransaction.Commit();
@@ -88,10 +123,31 @@ internal sealed class SqlitePeakAnalysisStore : IPeakAnalysisPointWriter, IDispo
         }
         finally
         {
-            insertCommand?.Dispose();
             transaction?.Dispose();
             connection?.Dispose();
         }
+    }
+
+    private void FlushPendingRows()
+    {
+        if (pendingRows.Count == 0)
+        {
+            return;
+        }
+
+        SqliteConnection currentConnection = connection
+            ?? throw new InvalidOperationException("SqlitePeakAnalysisStore is not initialized.");
+        SqliteTransaction currentTransaction = transaction
+            ?? throw new InvalidOperationException("SqlitePeakAnalysisStore is not initialized.");
+
+        using SqliteCommand command = BuildInsertCommand(
+            currentConnection,
+            currentTransaction,
+            tableName,
+            conflictMode,
+            pendingRows);
+        _ = command.ExecuteNonQuery();
+        pendingRows.Clear();
     }
 
     private static string BuildConnectionString(string dbFilePath)
@@ -105,6 +161,19 @@ internal sealed class SqlitePeakAnalysisStore : IPeakAnalysisPointWriter, IDispo
         };
 
         return builder.ToString();
+    }
+
+    private static bool TableExists(SqliteConnection connection, string tableName)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
+
+        using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(1) FROM sqlite_master WHERE type = 'table' AND name = $name;";
+        _ = command.Parameters.AddWithValue("$name", tableName);
+
+        object? scalar = command.ExecuteScalar();
+        return scalar is long count && count > 0;
     }
 
     private static void CreateTableIfNeeded(SqliteConnection connection, SqliteTransaction transaction, string tableName)
@@ -125,8 +194,7 @@ internal sealed class SqlitePeakAnalysisStore : IPeakAnalysisPointWriter, IDispo
               "ms" INTEGER NOT NULL,
               "db" REAL NOT NULL,
               "create_at" INTEGER NOT NULL,
-              "modified_at" INTEGER NOT NULL,
-              UNIQUE("name", "stem", "window", "ms")
+              "modified_at" INTEGER NOT NULL
             );
             """);
 
@@ -147,6 +215,7 @@ internal sealed class SqlitePeakAnalysisStore : IPeakAnalysisPointWriter, IDispo
 
         string[] statements =
         {
+            BuildUniqueIndexStatement(safePrefix, quotedTable, "name", "stem", "window", "ms"),
             BuildIndexStatement(safePrefix, "name", quotedTable, "name"),
             BuildIndexStatement(safePrefix, "name_stem", quotedTable, "name", "stem"),
             BuildIndexStatement(safePrefix, "name_ms", quotedTable, "name", "ms"),
@@ -160,6 +229,20 @@ internal sealed class SqlitePeakAnalysisStore : IPeakAnalysisPointWriter, IDispo
             command.CommandText = statements[i];
             _ = command.ExecuteNonQuery();
         }
+    }
+
+    private static string BuildUniqueIndexStatement(string prefix, string quotedTable, params string[] columns)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(prefix);
+        ArgumentException.ThrowIfNullOrWhiteSpace(quotedTable);
+        ArgumentNullException.ThrowIfNull(columns);
+
+        string indexName = QuoteIdentifier(string.Create(CultureInfo.InvariantCulture, $"UX_{prefix}_name_stem_window_ms"));
+        string joinedColumns = string.Join(", ", columns.Select(column => QuoteIdentifier(column)));
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"CREATE UNIQUE INDEX IF NOT EXISTS {indexName} ON {quotedTable} ({joinedColumns});");
     }
 
     private static string BuildIndexStatement(string prefix, string suffix, string quotedTable, params string[] columns)
@@ -181,53 +264,63 @@ internal sealed class SqlitePeakAnalysisStore : IPeakAnalysisPointWriter, IDispo
         SqliteConnection connection,
         SqliteTransaction transaction,
         string tableName,
-        SqliteConflictMode conflictMode)
+        SqliteConflictMode conflictMode,
+        IReadOnlyList<PeakInsertRow> rows)
     {
         ArgumentNullException.ThrowIfNull(connection);
         ArgumentNullException.ThrowIfNull(transaction);
         ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
+        ArgumentNullException.ThrowIfNull(rows);
+
+        if (rows.Count == 0)
+        {
+            throw new ArgumentException("At least one row is required.", nameof(rows));
+        }
 
         string quotedTable = QuoteIdentifier(tableName);
-
-        string sql = conflictMode switch
-        {
-            SqliteConflictMode.Upsert => string.Create(
-                CultureInfo.InvariantCulture,
-                $"""
-                INSERT INTO {quotedTable} ("name", "stem", "window", "ms", "db", "create_at", "modified_at")
-                VALUES ($name, $stem, $window, $ms, $db, $createAt, $modifiedAt)
-                ON CONFLICT("name", "stem", "window", "ms") DO UPDATE SET
-                  "db" = excluded."db",
-                  "modified_at" = excluded."modified_at";
-                """),
-            SqliteConflictMode.SkipDuplicate => string.Create(
-                CultureInfo.InvariantCulture,
-                $"""
-                INSERT INTO {quotedTable} ("name", "stem", "window", "ms", "db", "create_at", "modified_at")
-                VALUES ($name, $stem, $window, $ms, $db, $createAt, $modifiedAt)
-                ON CONFLICT("name", "stem", "window", "ms") DO NOTHING;
-                """),
-            _ => string.Create(
-                CultureInfo.InvariantCulture,
-                $"""
-                INSERT INTO {quotedTable} ("name", "stem", "window", "ms", "db", "create_at", "modified_at")
-                VALUES ($name, $stem, $window, $ms, $db, $createAt, $modifiedAt);
-                """),
-        };
-
         SqliteCommand command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText = sql;
 
-        _ = command.Parameters.Add("$name", SqliteType.Text);
-        _ = command.Parameters.Add("$stem", SqliteType.Text);
-        _ = command.Parameters.Add("$window", SqliteType.Integer);
-        _ = command.Parameters.Add("$ms", SqliteType.Integer);
-        _ = command.Parameters.Add("$db", SqliteType.Real);
-        _ = command.Parameters.Add("$createAt", SqliteType.Integer);
-        _ = command.Parameters.Add("$modifiedAt", SqliteType.Integer);
+        StringBuilder valuesBuilder = new();
+        for (int i = 0; i < rows.Count; i++)
+        {
+            if (i > 0)
+            {
+                _ = valuesBuilder.Append(", ");
+            }
+
+            _ = valuesBuilder.Append('(');
+            _ = valuesBuilder.Append(
+                string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"$name{i}, $stem{i}, $window{i}, $ms{i}, $db{i}, $createAt{i}, $modifiedAt{i}"));
+            _ = valuesBuilder.Append(')');
+
+            PeakInsertRow row = rows[i];
+            _ = command.Parameters.AddWithValue($"$name{i}", row.Name);
+            _ = command.Parameters.AddWithValue($"$stem{i}", row.Stem);
+            _ = command.Parameters.AddWithValue($"$window{i}", row.WindowMs);
+            _ = command.Parameters.AddWithValue($"$ms{i}", row.Ms);
+            _ = command.Parameters.AddWithValue($"$db{i}", row.Db);
+            _ = command.Parameters.AddWithValue($"$createAt{i}", row.CreateAt);
+            _ = command.Parameters.AddWithValue($"$modifiedAt{i}", row.ModifiedAt);
+        }
+
+        string prefix = string.Create(
+            CultureInfo.InvariantCulture,
+            $"INSERT INTO {quotedTable} (\"name\", \"stem\", \"window\", \"ms\", \"db\", \"create_at\", \"modified_at\") VALUES ");
+
+        string conflictClause = conflictMode switch
+        {
+            SqliteConflictMode.Upsert =>
+                " ON CONFLICT(\"name\", \"stem\", \"window\", \"ms\") DO UPDATE SET \"db\" = excluded.\"db\", \"modified_at\" = excluded.\"modified_at\"",
+            SqliteConflictMode.SkipDuplicate =>
+                " ON CONFLICT(\"name\", \"stem\", \"window\", \"ms\") DO NOTHING",
+            _ => string.Empty,
+        };
+
+        command.CommandText = string.Concat(prefix, valuesBuilder.ToString(), conflictClause, ";");
         command.Prepare();
-
         return command;
     }
 
@@ -238,5 +331,14 @@ internal sealed class SqlitePeakAnalysisStore : IPeakAnalysisPointWriter, IDispo
         string escaped = identifier.Replace("\"", "\"\"", StringComparison.Ordinal);
         return string.Create(CultureInfo.InvariantCulture, $"\"{escaped}\"");
     }
+
+    private readonly record struct PeakInsertRow(
+        string Name,
+        string Stem,
+        long WindowMs,
+        long Ms,
+        double Db,
+        long CreateAt,
+        long ModifiedAt);
 }
 #pragma warning restore CA2100

--- a/SoundAnalyzer.Cli/Infrastructure/Sqlite/SqliteWriteOptions.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Sqlite/SqliteWriteOptions.cs
@@ -1,0 +1,18 @@
+namespace SoundAnalyzer.Cli.Infrastructure.Sqlite;
+
+internal sealed class SqliteWriteOptions
+{
+    public SqliteWriteOptions(bool fastMode, int batchRowCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(batchRowCount);
+
+        FastMode = fastMode;
+        BatchRowCount = batchRowCount;
+    }
+
+    public bool FastMode { get; }
+
+    public int BatchRowCount { get; }
+
+    public static SqliteWriteOptions Default { get; } = new(fastMode: false, batchRowCount: 512);
+}

--- a/SoundAnalyzer.Cli/Presentation/Cli/Arguments/CommandLineArguments.cs
+++ b/SoundAnalyzer.Cli/Presentation/Cli/Arguments/CommandLineArguments.cs
@@ -25,6 +25,8 @@ internal sealed class CommandLineArguments
         int stftFileThreads,
         int peakFileThreads,
         int insertQueueSize,
+        bool sqliteFastMode,
+        int sqliteBatchRowCount,
         bool showProgress)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(windowValue);
@@ -38,6 +40,7 @@ internal sealed class CommandLineArguments
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(stftFileThreads);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(peakFileThreads);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(insertQueueSize);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(sqliteBatchRowCount);
 
         if (targetSamplingHz.HasValue)
         {
@@ -76,6 +79,8 @@ internal sealed class CommandLineArguments
         StftFileThreads = stftFileThreads;
         PeakFileThreads = peakFileThreads;
         InsertQueueSize = insertQueueSize;
+        SqliteFastMode = sqliteFastMode;
+        SqliteBatchRowCount = sqliteBatchRowCount;
         ShowProgress = showProgress;
     }
 
@@ -122,6 +127,10 @@ internal sealed class CommandLineArguments
     public int PeakFileThreads { get; }
 
     public int InsertQueueSize { get; }
+
+    public bool SqliteFastMode { get; }
+
+    public int SqliteBatchRowCount { get; }
 
     public bool ShowProgress { get; }
 

--- a/SoundAnalyzer.Cli/Presentation/Cli/Texts/ConsoleTexts.cs
+++ b/SoundAnalyzer.Cli/Presentation/Cli/Texts/ConsoleTexts.cs
@@ -23,6 +23,8 @@ internal static class ConsoleTexts
     public const string StftFileThreadsOption = "--stft-file-threads";
     public const string PeakFileThreadsOption = "--peak-file-threads";
     public const string InsertQueueSizeOption = "--insert-queue-size";
+    public const string SqliteFastModeOption = "--sqlite-fast-mode";
+    public const string SqliteBatchRowCountOption = "--sqlite-batch-row-count";
     public const string FfmpegPathOption = "--ffmpeg-path";
     public const string ShowProgressOption = "--show-progress";
     public const string HelpOption = "--help";
@@ -61,6 +63,9 @@ Optional:
   --stft-file-threads <n>   STFT mode only. Number of files analyzed in parallel (default: 1)
   --peak-file-threads <n>   Peak mode only. Number of songs analyzed in parallel (default: 1)
   --insert-queue-size <n>   Bounded queue size between analyze and DB insert (default: 1024)
+  --sqlite-fast-mode        Enable SQLite write-speed PRAGMA tuning (durability trade-off)
+  --sqlite-batch-row-count <n>
+                            SQLite multi-row INSERT batch size (default: 512)
   --ffmpeg-path <path>      ffmpeg executable path or directory containing ffmpeg/ffprobe
   --show-progress           Show advanced progress UI on interactive stderr
   --help, -h                Show help

--- a/build-logs/2026-02-24T231341-issue19-sqlite-bulk-build.txt
+++ b/build-logs/2026-02-24T231341-issue19-sqlite-bulk-build.txt
@@ -1,0 +1,22 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+
+ビルドに成功しました。
+    0 個の警告
+    0 エラー
+
+経過時間 00:00:02.64

--- a/build-logs/2026-02-24T231344-issue19-sqlite-bulk-test.txt
+++ b/build-logs/2026-02-24T231344-issue19-sqlite-bulk-test.txt
@@ -1,0 +1,65 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+VSTest のバージョン 18.0.1 (x64)
+
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+テスト実行を開始しています。お待ちください...
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+VSTest のバージョン 18.0.1 (x64)
+VSTest のバージョン 18.0.1 (x64)
+
+
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+テスト実行を開始しています。お待ちください...
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+
+成功!   -失敗:     0、合格:    12、スキップ:     0、合計:    12、期間: 118 ms - AudioProcessor.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    21、スキップ:     0、合計:    21、期間: 141 ms - Cli.Shared.Tests.dll (net10.0)
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+
+成功!   -失敗:     0、合格:     8、スキップ:     0、合計:     8、期間: 132 ms - AudioSplitter.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:     5、スキップ:     0、合計:     5、期間: 139 ms - PeakAnalyzer.Core.Tests.dll (net10.0)
+VSTest のバージョン 18.0.1 (x64)
+
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+
+成功!   -失敗:     0、合格:     7、スキップ:     0、合計:     7、期間: 250 ms - STFTAnalyzer.Core.Tests.dll (net10.0)
+C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+テスト実行を開始しています。お待ちください...
+VSTest のバージョン 18.0.1 (x64)
+
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:    15、スキップ:     0、合計:    15、期間: 101 ms - AudioSplitter.Cli.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    61、スキップ:     0、合計:    61、期間: 2 s - SoundAnalyzer.Cli.Tests.dll (net10.0)


### PR DESCRIPTION
## Summary
- add SQLite write tuning options to CLI: `--sqlite-fast-mode` and `--sqlite-batch-row-count`
- implement shared SQLite batch-size limiter via `MAX_VARIABLE_NUMBER` (`PRAGMA compile_options`, fallback 999)
- switch STFT/Peak stores from per-row command execution to multi-row batched INSERT
- apply optional fast-mode PRAGMAs (`synchronous=OFF`, `locking_mode=EXCLUSIVE`, `temp_store=MEMORY`, `cache_size=-262144`)
- implement deferred unique/secondary index creation for new table + conflict mode Error path
- update README/CLI docs and add regression tests for parser/store behaviors

## Validation
- `dotnet build AudioProcessor.slnx -warnaserror`
- `dotnet test AudioProcessor.slnx`
- build/test logs added under `build-logs/`:
  - `2026-02-24T231341-issue19-sqlite-bulk-build.txt`
  - `2026-02-24T231344-issue19-sqlite-bulk-test.txt`

Fixes #19