### PR TITLE
Add Windows/Linux requirement docs and CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  build-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore
+        run: dotnet restore AudioProcessor.slnx
+
+      - name: Build (warn as error)
+        run: dotnet build AudioProcessor.slnx -warnaserror --no-restore
+
+      - name: Test
+        run: dotnet test AudioProcessor.slnx --no-build

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ WAL 非対応環境では既存ジャーナルモードへ自動フォールバ�
 
 - `.NET SDK 10.x`
 - 音声処理に必要な外部ツールが利用可能であること（現行実装では `ffmpeg` / `ffprobe`。CLI オプション `--ffmpeg-path` でパス指定可能）
-- Windows / Linux / macOS で動作可能（実行確認は環境依存）
+- Windows / Linux は必須サポート対象
+- macOS は任意検証対象
 
 ## 最小コマンド
 
@@ -113,6 +114,18 @@ dotnet run --project SoundAnalyzer.Cli -- \
   --mode stft-analysis \
   --bin-count 24 \
   --upsert
+```
+
+### SoundAnalyzer.Cli (Windows 実行例)
+
+```powershell
+SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir C:\audio\split --db-file C:\data\analyze.db --mode stft-analysis --bin-count 12 --sqlite-batch-row-count 512 --sqlite-fast-mode
+```
+
+### SoundAnalyzer.Cli (Linux 実行例)
+
+```bash
+dotnet SoundAnalyzer.Cli.dll --window-size 50ms --hop 10ms --input-dir /data/audio/split --db-file /data/analyze.db --mode stft-analysis --bin-count 12 --sqlite-batch-row-count 512 --sqlite-fast-mode
 ```
 
 ## ライセンス

--- a/SoundAnalyzer.Cli.Tests/Presentation/Cli/Arguments/CommandLineParserTests.cs
+++ b/SoundAnalyzer.Cli.Tests/Presentation/Cli/Arguments/CommandLineParserTests.cs
@@ -308,6 +308,51 @@ public sealed class CommandLineParserTests
     }
 
     [Fact]
+    public void Parse_ShouldAcceptWindowsStylePaths()
+    {
+        string[] args =
+        [
+            "--window-size", "50ms",
+            "--hop", "10ms",
+            "--input-dir", @"C:\audio\input",
+            "--db-file", @"C:\data\analysis.db",
+            "--ffmpeg-path", @"C:\tools\ffmpeg",
+            "--mode", "peak-analysis",
+        ];
+
+        CommandLineParseResult result = CommandLineParser.Parse(args);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Arguments);
+        Assert.Equal(@"C:\audio\input", result.Arguments.InputDirectoryPath, StringComparer.Ordinal);
+        Assert.Equal(@"C:\data\analysis.db", result.Arguments.DbFilePath, StringComparer.Ordinal);
+        Assert.Equal(@"C:\tools\ffmpeg", result.Arguments.FfmpegPath, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_ShouldAcceptLinuxStylePaths()
+    {
+        string[] args =
+        [
+            "--window-size", "50ms",
+            "--hop", "10ms",
+            "--input-dir", "/mnt/audio/input",
+            "--db-file", "/var/tmp/analysis.db",
+            "--ffmpeg-path", "/usr/bin",
+            "--mode", "stft-analysis",
+            "--bin-count", "12",
+        ];
+
+        CommandLineParseResult result = CommandLineParser.Parse(args);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Arguments);
+        Assert.Equal("/mnt/audio/input", result.Arguments.InputDirectoryPath, StringComparer.Ordinal);
+        Assert.Equal("/var/tmp/analysis.db", result.Arguments.DbFilePath, StringComparer.Ordinal);
+        Assert.Equal("/usr/bin", result.Arguments.FfmpegPath, StringComparer.Ordinal);
+    }
+
+    [Fact]
     public void Parse_ShouldEnableShowProgress_WhenShowProgressOptionIsSpecified()
     {
         string[] args =

--- a/SoundAnalyzer.Cli/README.md
+++ b/SoundAnalyzer.Cli/README.md
@@ -4,11 +4,24 @@
 `SoundAnalyzer.Cli` はディレクトリ配下の音声ファイルを一括解析し、結果を SQLite へ保存する CLI です。  
 `peak-analysis` は `PeakAnalyzer.Core`、`stft-analysis` は `STFTAnalyzer.Core` を利用します。
 
+Windows / Linux は必須サポート対象です（SQLite モード・Postgres モードの双方で同一方針を適用します）。
+macOS は任意検証対象です。
+
 ## 実行形式
 
 ```powershell
 SoundAnalyzer.Cli.exe --window-size <len> --hop <len> --input-dir <path> --db-file <path> --mode <peak-analysis|stft-analysis> [options]
 ```
+
+```bash
+dotnet SoundAnalyzer.Cli.dll --window-size <len> --hop <len> --input-dir <path> --db-file <path> --mode <peak-analysis|stft-analysis> [options]
+```
+
+## クロスプラットフォーム方針
+
+- パス解釈は OS 依存の区切り文字を前提にせず、`.NET` の `Path` API を基準とします。
+- 証明書/鍵/known_hosts を含むファイル読み込みは `.NET` 標準 I/O で統一します。
+- エラーメッセージは OS 固有コマンド名に依存しない共通文言を採用します。
 
 ## オプション
 
@@ -158,4 +171,10 @@ SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --d
 
 ```powershell
 SoundAnalyzer.Cli.exe --window-size 2048samples --hop 512samples --target-sampling 44100hz --input-dir /path/to/dir --db-file /path/to/file.db --mode stft-analysis --bin-count 24 --upsert
+```
+
+### Linux 実行例（stft-analysis）
+
+```bash
+dotnet SoundAnalyzer.Cli.dll --window-size 2048samples --hop 512samples --target-sampling 44100hz --input-dir /path/to/dir --db-file /path/to/file.db --mode stft-analysis --bin-count 24 --upsert
 ```

--- a/build-logs/2026-02-25T023627-issue21-windows-linux-build.txt
+++ b/build-logs/2026-02-25T023627-issue21-windows-linux-build.txt
@@ -1,0 +1,22 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+
+ビルドに成功しました。
+    0 個の警告
+    0 エラー
+
+経過時間 00:00:03.76

--- a/build-logs/2026-02-25T023631-issue21-windows-linux-test.txt
+++ b/build-logs/2026-02-25T023631-issue21-windows-linux-test.txt
@@ -1,0 +1,49 @@
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+VSTest のバージョン 18.0.1 (x64)
+VSTest のバージョン 18.0.1 (x64)
+
+
+VSTest のバージョン 18.0.1 (x64)
+
+VSTest のバージョン 18.0.1 (x64)
+
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+テスト実行を開始しています。お待ちください...
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:    21、スキップ:     0、合計:    21、期間: 506 ms - Cli.Shared.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    12、スキップ:     0、合計:    12、期間: 53 ms - AudioProcessor.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:     5、スキップ:     0、合計:     5、期間: 422 ms - PeakAnalyzer.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:     8、スキップ:     0、合計:     8、期間: 532 ms - AudioSplitter.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:     7、スキップ:     0、合計:     7、期間: 507 ms - STFTAnalyzer.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    15、スキップ:     0、合計:    15、期間: 671 ms - AudioSplitter.Cli.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    63、スキップ:     0、合計:    63、期間: 2 s - SoundAnalyzer.Cli.Tests.dll (net10.0)


### PR DESCRIPTION
## Summary
- add explicit Windows/Linux support statement and execution examples in README docs
- add parser tests for Windows-style and Linux-style path inputs
- add GitHub Actions matrix CI for `windows-latest` and `ubuntu-latest`
- remove CLI smoke steps from CI and keep build/test only

## Validation
- dotnet build AudioProcessor.slnx -warnaserror
- dotnet test AudioProcessor.slnx --no-build
- logs:
  - build-logs/2026-02-25T023627-issue21-windows-linux-build.txt
  - build-logs/2026-02-25T023631-issue21-windows-linux-test.txt

Fixes #21