### PR TITLE
Add Postgres storage mode for Peak/STFT in SoundAnalyzer.Cli

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,9 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Npgsql" Version="8.0.4" />
     <PackageVersion Include="NAudio" Version="2.2.1" />
+    <PackageVersion Include="SSH.NET" Version="2024.2.0" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" />
     <PackageVersion Include="System.Drawing.Common" Version="10.0.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
@@ -19,4 +21,3 @@
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.0" />
   </ItemGroup>
 </Project>
-

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ AudioProcessor は、オーディオ解析・変換ツール群を提供する .
 現時点では次の実行可能な機能を提供しています。
 
 - 無音区間ベース分割: `AudioSplitter.Cli`
-- 窓ピーク dB 解析 + SQLite 保存: `SoundAnalyzer.Cli --mode peak-analysis`
-- 窓STFT解析（チャネル別band dB）+ SQLite 保存: `SoundAnalyzer.Cli --mode stft-analysis`
+- 窓ピーク dB 解析 + SQLite/PostgreSQL 保存: `SoundAnalyzer.Cli --mode peak-analysis`
+- 窓STFT解析（チャネル別band dB）+ SQLite/PostgreSQL 保存: `SoundAnalyzer.Cli --mode stft-analysis`
   - `--window-size` / `--hop` は `ms/s/m/sample/samples` を受理
   - `sample(s)` を1つでも使う場合は `--target-sampling <n>hz` が必須
   - STFT bin は `bin_no` / `db` の縦持ち行として保存（列数上限依存を回避）
@@ -25,7 +25,7 @@ AudioProcessor は、オーディオ解析・変換ツール群を提供する .
 | `AudioSplitter.Cli` | CLI | 無音分割のコマンドライン実行層 |
 | `PeakAnalyzer.Core` | Library | hop/window ベースのピーク dB 窓解析コア |
 | `STFTAnalyzer.Core` | Library | hop/window ベースの短時間FFT band解析コア |
-| `SoundAnalyzer.Cli` | CLI | ディレクトリ一括解析と SQLite 永続化 |
+| `SoundAnalyzer.Cli` | CLI | ディレクトリ一括解析と SQLite/PostgreSQL 永続化 |
 | `AudioProcessor.Tests` | Test | `AudioProcessor` の単体テスト |
 | `Cli.Shared.Tests` | Test | `Cli.Shared` の単体テスト |
 | `AudioSplitter.Core.Tests` | Test | `AudioSplitter.Core` の単体テスト |
@@ -45,6 +45,9 @@ WAL 非対応環境では既存ジャーナルモードへ自動フォールバ�
 
 `--sqlite-fast-mode` 指定時は `synchronous=OFF` など速度優先PRAGMAを追加で適用します。  
 異常終了時の破損/欠損リスクが上がるため、投入ジョブ専用DB・バックアップ運用を推奨します。
+
+`--postgres` 指定時は PostgreSQL 保存モードへ切り替わります。  
+`--postgres-host/--postgres-port/--postgres-db/--postgres-user` が必須で、`--db-file` は指定できません。
 
 ## 前提環境
 
@@ -126,6 +129,12 @@ SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir C:\audio\split -
 
 ```bash
 dotnet SoundAnalyzer.Cli.dll --window-size 50ms --hop 10ms --input-dir /data/audio/split --db-file /data/analyze.db --mode stft-analysis --bin-count 12 --sqlite-batch-row-count 512 --sqlite-fast-mode
+```
+
+### SoundAnalyzer.Cli (PostgreSQL 実行例)
+
+```powershell
+SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir C:\audio\split --mode stft-analysis --bin-count 12 --postgres --postgres-host 127.0.0.1 --postgres-port 5432 --postgres-db audio --postgres-user analyzer --postgres-password secret --show-progress
 ```
 
 ## ライセンス

--- a/SoundAnalyzer.Cli.Tests/Infrastructure/Postgres/PostgresPeakAnalysisStoreTests.cs
+++ b/SoundAnalyzer.Cli.Tests/Infrastructure/Postgres/PostgresPeakAnalysisStoreTests.cs
@@ -1,0 +1,176 @@
+using System.Globalization;
+using Npgsql;
+using PeakAnalyzer.Core.Domain.Models;
+using SoundAnalyzer.Cli.Infrastructure.Postgres;
+using SoundAnalyzer.Cli.Infrastructure.Sqlite;
+
+namespace SoundAnalyzer.Cli.Tests.Infrastructure.Postgres;
+
+#pragma warning disable CA2100
+public sealed class PostgresPeakAnalysisStoreTests
+{
+    [Fact]
+    public void InitializeAndWrite_ShouldCreateTableAndInsertRow()
+    {
+        PostgresConnectionOptions? connectionOptions = PostgresTestEnvironment.GetConnectionOptionsOrNull();
+        if (connectionOptions is null)
+        {
+            return;
+        }
+        string tableName = PostgresTestEnvironment.CreateRandomTableName("t_peak_pg");
+
+        try
+        {
+            using (PostgresPeakAnalysisStore store = new(
+                       connectionOptions,
+                       sshOptions: null,
+                       tableName,
+                       SqliteConflictMode.Error))
+            {
+                store.Initialize();
+                store.Write(new PeakAnalysisPoint("SongA", "Piano", 50, 10, -12.5));
+                store.Complete();
+            }
+
+            Assert.True(TableExists(connectionOptions, tableName));
+            Assert.Equal(1, ReadRowCount(connectionOptions, tableName));
+        }
+        finally
+        {
+            DropTableIfExists(connectionOptions, tableName);
+        }
+    }
+
+    [Fact]
+    public void Write_ShouldUpsertByUniqueKey()
+    {
+        PostgresConnectionOptions? connectionOptions = PostgresTestEnvironment.GetConnectionOptionsOrNull();
+        if (connectionOptions is null)
+        {
+            return;
+        }
+        string tableName = PostgresTestEnvironment.CreateRandomTableName("t_peak_pg");
+
+        try
+        {
+            PeakAnalysisPoint point = new("SongA", "Piano", 50, 10, -12.0);
+            using (PostgresPeakAnalysisStore store = new(
+                       connectionOptions,
+                       sshOptions: null,
+                       tableName,
+                       SqliteConflictMode.Upsert))
+            {
+                store.Initialize();
+                store.Write(point);
+                store.Complete();
+            }
+
+            using (PostgresPeakAnalysisStore store = new(
+                       connectionOptions,
+                       sshOptions: null,
+                       tableName,
+                       SqliteConflictMode.Upsert))
+            {
+                store.Initialize();
+                store.Write(new PeakAnalysisPoint("SongA", "Piano", 50, 10, -3.0));
+                store.Complete();
+            }
+
+            Assert.Equal(1, ReadRowCount(connectionOptions, tableName));
+            Assert.Equal(-3.0, ReadDb(connectionOptions, tableName), precision: 6);
+        }
+        finally
+        {
+            DropTableIfExists(connectionOptions, tableName);
+        }
+    }
+
+    [Fact]
+    public void Write_ShouldSkipDuplicate_WhenSkipDuplicateMode()
+    {
+        PostgresConnectionOptions? connectionOptions = PostgresTestEnvironment.GetConnectionOptionsOrNull();
+        if (connectionOptions is null)
+        {
+            return;
+        }
+        string tableName = PostgresTestEnvironment.CreateRandomTableName("t_peak_pg");
+
+        try
+        {
+            PeakAnalysisPoint point = new("SongA", "Piano", 50, 10, -12.0);
+            using (PostgresPeakAnalysisStore store = new(
+                       connectionOptions,
+                       sshOptions: null,
+                       tableName,
+                       SqliteConflictMode.SkipDuplicate))
+            {
+                store.Initialize();
+                store.Write(point);
+                store.Write(point);
+                store.Complete();
+            }
+
+            Assert.Equal(1, ReadRowCount(connectionOptions, tableName));
+        }
+        finally
+        {
+            DropTableIfExists(connectionOptions, tableName);
+        }
+    }
+
+    private static bool TableExists(PostgresConnectionOptions options, string tableName)
+    {
+        using NpgsqlConnection connection = PostgresTestEnvironment.OpenConnection(options);
+        using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText =
+            """
+            SELECT COUNT(1)
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.relkind = 'r'
+              AND n.nspname = current_schema()
+              AND c.relname = @table_name;
+            """;
+        _ = command.Parameters.AddWithValue("@table_name", tableName);
+        object? scalar = command.ExecuteScalar();
+        return scalar is long count && count > 0;
+    }
+
+    private static long ReadRowCount(PostgresConnectionOptions options, string tableName)
+    {
+        using NpgsqlConnection connection = PostgresTestEnvironment.OpenConnection(options);
+        using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = string.Create(CultureInfo.InvariantCulture, $"SELECT COUNT(1) FROM {QuoteIdentifier(tableName)};");
+        object? scalar = command.ExecuteScalar();
+        return scalar is long count ? count : 0;
+    }
+
+    private static double ReadDb(PostgresConnectionOptions options, string tableName)
+    {
+        using NpgsqlConnection connection = PostgresTestEnvironment.OpenConnection(options);
+        using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = string.Create(
+            CultureInfo.InvariantCulture,
+            $"SELECT \"db\" FROM {QuoteIdentifier(tableName)} WHERE \"name\"='SongA' AND \"stem\"='Piano' AND \"window\"=50 AND \"ms\"=10;");
+        object? scalar = command.ExecuteScalar();
+        return scalar is double value ? value : 0.0;
+    }
+
+    private static void DropTableIfExists(PostgresConnectionOptions options, string tableName)
+    {
+        using NpgsqlConnection connection = PostgresTestEnvironment.OpenConnection(options);
+        using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = string.Create(
+            CultureInfo.InvariantCulture,
+            $"DROP TABLE IF EXISTS {QuoteIdentifier(tableName)};");
+        _ = command.ExecuteNonQuery();
+    }
+
+    private static string QuoteIdentifier(string identifier)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(identifier);
+        string escaped = identifier.Replace("\"", "\"\"", StringComparison.Ordinal);
+        return string.Create(CultureInfo.InvariantCulture, $"\"{escaped}\"");
+    }
+}
+#pragma warning restore CA2100

--- a/SoundAnalyzer.Cli.Tests/Infrastructure/Postgres/PostgresStftAnalysisStoreTests.cs
+++ b/SoundAnalyzer.Cli.Tests/Infrastructure/Postgres/PostgresStftAnalysisStoreTests.cs
@@ -1,0 +1,315 @@
+using System.Globalization;
+using Npgsql;
+using STFTAnalyzer.Core.Domain.Models;
+using SoundAnalyzer.Cli.Infrastructure.Execution;
+using SoundAnalyzer.Cli.Infrastructure.Postgres;
+using SoundAnalyzer.Cli.Infrastructure.Sqlite;
+
+namespace SoundAnalyzer.Cli.Tests.Infrastructure.Postgres;
+
+#pragma warning disable CA2100
+public sealed class PostgresStftAnalysisStoreTests
+{
+    [Fact]
+    public void InitializeAndWrite_ShouldCreateTableAndInsertRows()
+    {
+        PostgresConnectionOptions? connectionOptions = PostgresTestEnvironment.GetConnectionOptionsOrNull();
+        if (connectionOptions is null)
+        {
+            return;
+        }
+        string tableName = PostgresTestEnvironment.CreateRandomTableName("t_stft_pg");
+
+        try
+        {
+            using (PostgresStftAnalysisStore store = new(
+                       connectionOptions,
+                       sshOptions: null,
+                       tableName,
+                       anchorColumnName: "ms",
+                       conflictMode: SqliteConflictMode.Error,
+                       binCount: 4,
+                       deleteCurrent: false))
+            {
+                store.Initialize();
+                store.Write(new StftAnalysisPoint("SongA", 0, 50, 10, CreateBins(4, -12.0)));
+                store.Complete();
+            }
+
+            Assert.Equal(4, ReadRowCount(connectionOptions, tableName));
+        }
+        finally
+        {
+            DropTableIfExists(connectionOptions, tableName);
+        }
+    }
+
+    [Fact]
+    public void Write_ShouldUpsertAndSkipDuplicate()
+    {
+        PostgresConnectionOptions? connectionOptions = PostgresTestEnvironment.GetConnectionOptionsOrNull();
+        if (connectionOptions is null)
+        {
+            return;
+        }
+        string tableName = PostgresTestEnvironment.CreateRandomTableName("t_stft_pg");
+
+        try
+        {
+            using (PostgresStftAnalysisStore store = new(
+                       connectionOptions,
+                       sshOptions: null,
+                       tableName,
+                       anchorColumnName: "ms",
+                       conflictMode: SqliteConflictMode.Upsert,
+                       binCount: 4,
+                       deleteCurrent: false))
+            {
+                store.Initialize();
+                store.Write(new StftAnalysisPoint("SongA", 0, 50, 10, CreateBins(4, -12.0)));
+                store.Complete();
+            }
+
+            using (PostgresStftAnalysisStore store = new(
+                       connectionOptions,
+                       sshOptions: null,
+                       tableName,
+                       anchorColumnName: "ms",
+                       conflictMode: SqliteConflictMode.Upsert,
+                       binCount: 4,
+                       deleteCurrent: false))
+            {
+                store.Initialize();
+                store.Write(new StftAnalysisPoint("SongA", 0, 50, 10, CreateBins(4, -6.0)));
+                store.Complete();
+            }
+
+            Assert.Equal(4, ReadRowCount(connectionOptions, tableName));
+            Assert.Equal(-6.0, ReadBinDb(connectionOptions, tableName, 1), precision: 6);
+
+            using (PostgresStftAnalysisStore store = new(
+                       connectionOptions,
+                       sshOptions: null,
+                       tableName,
+                       anchorColumnName: "ms",
+                       conflictMode: SqliteConflictMode.SkipDuplicate,
+                       binCount: 4,
+                       deleteCurrent: false))
+            {
+                store.Initialize();
+                store.Write(new StftAnalysisPoint("SongA", 0, 50, 10, CreateBins(4, -2.0)));
+                store.Write(new StftAnalysisPoint("SongA", 0, 50, 10, CreateBins(4, -2.0)));
+                store.Complete();
+            }
+
+            Assert.Equal(4, ReadRowCount(connectionOptions, tableName));
+            Assert.Equal(-6.0, ReadBinDb(connectionOptions, tableName, 1), precision: 6);
+        }
+        finally
+        {
+            DropTableIfExists(connectionOptions, tableName);
+        }
+    }
+
+    [Fact]
+    public void Initialize_ShouldFail_WhenExistingBinCountDiffers()
+    {
+        PostgresConnectionOptions? connectionOptions = PostgresTestEnvironment.GetConnectionOptionsOrNull();
+        if (connectionOptions is null)
+        {
+            return;
+        }
+        string tableName = PostgresTestEnvironment.CreateRandomTableName("t_stft_pg");
+
+        try
+        {
+            using (PostgresStftAnalysisStore first = new(
+                       connectionOptions,
+                       sshOptions: null,
+                       tableName,
+                       anchorColumnName: "ms",
+                       conflictMode: SqliteConflictMode.Error,
+                       binCount: 4,
+                       deleteCurrent: false))
+            {
+                first.Initialize();
+                first.Write(new StftAnalysisPoint("SongA", 0, 50, 10, CreateBins(4, -12.0)));
+                first.Complete();
+            }
+
+            using PostgresStftAnalysisStore second = new(
+                connectionOptions,
+                sshOptions: null,
+                tableName,
+                anchorColumnName: "ms",
+                conflictMode: SqliteConflictMode.Error,
+                binCount: 8,
+                deleteCurrent: false);
+
+            CliException exception = Assert.Throws<CliException>(() => second.Initialize());
+            Assert.Equal(CliErrorCode.StftTableBinCountMismatch, exception.ErrorCode);
+        }
+        finally
+        {
+            DropTableIfExists(connectionOptions, tableName);
+        }
+    }
+
+    [Fact]
+    public void Initialize_ShouldFail_WhenSchemaAnchorIsDifferent()
+    {
+        PostgresConnectionOptions? connectionOptions = PostgresTestEnvironment.GetConnectionOptionsOrNull();
+        if (connectionOptions is null)
+        {
+            return;
+        }
+        string tableName = PostgresTestEnvironment.CreateRandomTableName("t_stft_pg");
+
+        try
+        {
+            using (PostgresStftAnalysisStore first = new(
+                       connectionOptions,
+                       sshOptions: null,
+                       tableName,
+                       anchorColumnName: "ms",
+                       conflictMode: SqliteConflictMode.Error,
+                       binCount: 4,
+                       deleteCurrent: false))
+            {
+                first.Initialize();
+                first.Complete();
+            }
+
+            using PostgresStftAnalysisStore second = new(
+                connectionOptions,
+                sshOptions: null,
+                tableName,
+                anchorColumnName: "sample",
+                conflictMode: SqliteConflictMode.Error,
+                binCount: 4,
+                deleteCurrent: false);
+
+            CliException exception = Assert.Throws<CliException>(() => second.Initialize());
+            Assert.Equal(CliErrorCode.StftTableSchemaMismatch, exception.ErrorCode);
+        }
+        finally
+        {
+            DropTableIfExists(connectionOptions, tableName);
+        }
+    }
+
+    [Fact]
+    public void Initialize_ShouldRecreateTable_WhenDeleteCurrentIsEnabled()
+    {
+        PostgresConnectionOptions? connectionOptions = PostgresTestEnvironment.GetConnectionOptionsOrNull();
+        if (connectionOptions is null)
+        {
+            return;
+        }
+        string tableName = PostgresTestEnvironment.CreateRandomTableName("t_stft_pg");
+
+        try
+        {
+            using (PostgresStftAnalysisStore first = new(
+                       connectionOptions,
+                       sshOptions: null,
+                       tableName,
+                       anchorColumnName: "ms",
+                       conflictMode: SqliteConflictMode.Error,
+                       binCount: 4,
+                       deleteCurrent: false))
+            {
+                first.Initialize();
+                first.Complete();
+            }
+
+            using (PostgresStftAnalysisStore second = new(
+                       connectionOptions,
+                       sshOptions: null,
+                       tableName,
+                       anchorColumnName: "sample",
+                       conflictMode: SqliteConflictMode.Error,
+                       binCount: 6,
+                       deleteCurrent: true))
+            {
+                second.Initialize();
+                second.Complete();
+            }
+
+            Assert.True(ColumnExists(connectionOptions, tableName, "sample"));
+            Assert.False(ColumnExists(connectionOptions, tableName, "ms"));
+        }
+        finally
+        {
+            DropTableIfExists(connectionOptions, tableName);
+        }
+    }
+
+    private static double[] CreateBins(int count, double value)
+    {
+        double[] bins = new double[count];
+        for (int i = 0; i < bins.Length; i++)
+        {
+            bins[i] = value;
+        }
+
+        return bins;
+    }
+
+    private static long ReadRowCount(PostgresConnectionOptions options, string tableName)
+    {
+        using NpgsqlConnection connection = PostgresTestEnvironment.OpenConnection(options);
+        using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = string.Create(CultureInfo.InvariantCulture, $"SELECT COUNT(1) FROM {QuoteIdentifier(tableName)};");
+        object? scalar = command.ExecuteScalar();
+        return scalar is long count ? count : 0;
+    }
+
+    private static double ReadBinDb(PostgresConnectionOptions options, string tableName, int binNo)
+    {
+        using NpgsqlConnection connection = PostgresTestEnvironment.OpenConnection(options);
+        using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = string.Create(
+            CultureInfo.InvariantCulture,
+            $"SELECT \"db\" FROM {QuoteIdentifier(tableName)} WHERE \"name\"='SongA' AND \"ch\"=0 AND \"window\"=50 AND \"ms\"=10 AND \"bin_no\"=@bin_no;");
+        _ = command.Parameters.AddWithValue("@bin_no", binNo);
+        object? scalar = command.ExecuteScalar();
+        return scalar is double value ? value : 0.0;
+    }
+
+    private static bool ColumnExists(PostgresConnectionOptions options, string tableName, string columnName)
+    {
+        using NpgsqlConnection connection = PostgresTestEnvironment.OpenConnection(options);
+        using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText =
+            """
+            SELECT COUNT(1)
+            FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = @table_name
+              AND lower(column_name) = lower(@column_name);
+            """;
+        _ = command.Parameters.AddWithValue("@table_name", tableName);
+        _ = command.Parameters.AddWithValue("@column_name", columnName);
+        object? scalar = command.ExecuteScalar();
+        return scalar is long count && count > 0;
+    }
+
+    private static void DropTableIfExists(PostgresConnectionOptions options, string tableName)
+    {
+        using NpgsqlConnection connection = PostgresTestEnvironment.OpenConnection(options);
+        using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = string.Create(
+            CultureInfo.InvariantCulture,
+            $"DROP TABLE IF EXISTS {QuoteIdentifier(tableName)};");
+        _ = command.ExecuteNonQuery();
+    }
+
+    private static string QuoteIdentifier(string identifier)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(identifier);
+        string escaped = identifier.Replace("\"", "\"\"", StringComparison.Ordinal);
+        return string.Create(CultureInfo.InvariantCulture, $"\"{escaped}\"");
+    }
+}
+#pragma warning restore CA2100

--- a/SoundAnalyzer.Cli.Tests/Infrastructure/Postgres/PostgresTestEnvironment.cs
+++ b/SoundAnalyzer.Cli.Tests/Infrastructure/Postgres/PostgresTestEnvironment.cs
@@ -1,0 +1,79 @@
+using System.Globalization;
+using Npgsql;
+using SoundAnalyzer.Cli.Infrastructure.Postgres;
+
+namespace SoundAnalyzer.Cli.Tests.Infrastructure.Postgres;
+
+internal static class PostgresTestEnvironment
+{
+    private const string HostEnv = "SOUNDANALYZER_PG_HOST";
+    private const string PortEnv = "SOUNDANALYZER_PG_PORT";
+    private const string DatabaseEnv = "SOUNDANALYZER_PG_DB";
+    private const string UserEnv = "SOUNDANALYZER_PG_USER";
+    private const string PasswordEnv = "SOUNDANALYZER_PG_PASSWORD";
+
+    public static PostgresConnectionOptions? GetConnectionOptionsOrNull()
+    {
+        string? host = Environment.GetEnvironmentVariable(HostEnv);
+        string? database = Environment.GetEnvironmentVariable(DatabaseEnv);
+        string? user = Environment.GetEnvironmentVariable(UserEnv);
+
+        if (string.IsNullOrWhiteSpace(host)
+            || string.IsNullOrWhiteSpace(database)
+            || string.IsNullOrWhiteSpace(user))
+        {
+            return null;
+        }
+
+        string? portText = Environment.GetEnvironmentVariable(PortEnv);
+        int port = 5432;
+        if (!string.IsNullOrWhiteSpace(portText))
+        {
+            if (!int.TryParse(portText, NumberStyles.None, CultureInfo.InvariantCulture, out port) || port <= 0)
+            {
+                return null;
+            }
+        }
+
+        string? password = Environment.GetEnvironmentVariable(PasswordEnv);
+        return new PostgresConnectionOptions(
+            host,
+            port,
+            database,
+            user,
+            password,
+            sslCertPath: null,
+            sslKeyPath: null,
+            sslRootCertPath: null);
+    }
+
+    public static NpgsqlConnection OpenConnection(PostgresConnectionOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        NpgsqlConnectionStringBuilder builder = new()
+        {
+            Host = options.Host,
+            Port = options.Port,
+            Database = options.Database,
+            Username = options.User,
+            Timeout = 15,
+            CommandTimeout = 120,
+        };
+
+        if (!string.IsNullOrWhiteSpace(options.Password))
+        {
+            builder.Password = options.Password;
+        }
+
+        NpgsqlConnection connection = new(builder.ConnectionString);
+        connection.Open();
+        return connection;
+    }
+
+    public static string CreateRandomTableName(string prefix)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(prefix);
+        return string.Create(CultureInfo.InvariantCulture, $"{prefix}_{Guid.NewGuid():N}");
+    }
+}

--- a/SoundAnalyzer.Cli/Infrastructure/Execution/AnalysisStoreFactory.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Execution/AnalysisStoreFactory.cs
@@ -1,0 +1,90 @@
+using SoundAnalyzer.Cli.Infrastructure.Postgres;
+using SoundAnalyzer.Cli.Infrastructure.Sqlite;
+using SoundAnalyzer.Cli.Presentation.Cli.Arguments;
+
+namespace SoundAnalyzer.Cli.Infrastructure.Execution;
+
+internal sealed class AnalysisStoreFactory : IAnalysisStoreFactory
+{
+    public IPeakAnalysisStore CreatePeakStore(CommandLineArguments arguments, SqliteConflictMode conflictMode)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        return arguments.StorageBackend switch
+        {
+            StorageBackend.Postgres => new PostgresPeakAnalysisStore(
+                BuildPostgresConnectionOptions(arguments),
+                BuildPostgresSshOptions(arguments),
+                arguments.TableName,
+                conflictMode),
+            _ => new SqlitePeakAnalysisStore(
+                arguments.DbFilePath ?? throw new CliException(CliErrorCode.DbFileRequired, "SQLite mode requires db file path."),
+                arguments.TableName,
+                conflictMode,
+                new SqliteWriteOptions(arguments.SqliteFastMode, arguments.SqliteBatchRowCount)),
+        };
+    }
+
+    public IStftAnalysisStore CreateStftStore(
+        CommandLineArguments arguments,
+        string anchorColumnName,
+        int binCount,
+        SqliteConflictMode conflictMode)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+        ArgumentException.ThrowIfNullOrWhiteSpace(anchorColumnName);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(binCount);
+
+        return arguments.StorageBackend switch
+        {
+            StorageBackend.Postgres => new PostgresStftAnalysisStore(
+                BuildPostgresConnectionOptions(arguments),
+                BuildPostgresSshOptions(arguments),
+                arguments.TableName,
+                anchorColumnName,
+                conflictMode,
+                binCount,
+                arguments.DeleteCurrent),
+            _ => new SqliteStftAnalysisStore(
+                arguments.DbFilePath ?? throw new CliException(CliErrorCode.DbFileRequired, "SQLite mode requires db file path."),
+                arguments.TableName,
+                anchorColumnName,
+                conflictMode,
+                binCount,
+                arguments.DeleteCurrent,
+                new SqliteWriteOptions(arguments.SqliteFastMode, arguments.SqliteBatchRowCount)),
+        };
+    }
+
+    private static PostgresConnectionOptions BuildPostgresConnectionOptions(CommandLineArguments arguments)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        return new PostgresConnectionOptions(
+            arguments.PostgresHost ?? throw new CliException(CliErrorCode.PostgresConfigurationInvalid, "postgres-host is required."),
+            arguments.PostgresPort ?? throw new CliException(CliErrorCode.PostgresConfigurationInvalid, "postgres-port is required."),
+            arguments.PostgresDatabase ?? throw new CliException(CliErrorCode.PostgresConfigurationInvalid, "postgres-db is required."),
+            arguments.PostgresUser ?? throw new CliException(CliErrorCode.PostgresConfigurationInvalid, "postgres-user is required."),
+            arguments.PostgresPassword,
+            arguments.PostgresSslCertPath,
+            arguments.PostgresSslKeyPath,
+            arguments.PostgresSslRootCertPath);
+    }
+
+    private static PostgresSshOptions? BuildPostgresSshOptions(CommandLineArguments arguments)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        if (string.IsNullOrWhiteSpace(arguments.PostgresSshHost))
+        {
+            return null;
+        }
+
+        return new PostgresSshOptions(
+            arguments.PostgresSshHost,
+            arguments.PostgresSshPort ?? 22,
+            arguments.PostgresSshUser ?? throw new CliException(CliErrorCode.PostgresConfigurationInvalid, "postgres-ssh-user is required."),
+            arguments.PostgresSshPrivateKeyPath ?? throw new CliException(CliErrorCode.PostgresConfigurationInvalid, "postgres-ssh-private-key-path is required."),
+            arguments.PostgresSshKnownHostsPath ?? throw new CliException(CliErrorCode.PostgresConfigurationInvalid, "postgres-ssh-known-hosts-path is required."));
+    }
+}

--- a/SoundAnalyzer.Cli/Infrastructure/Execution/BatchExecutionSupport.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Execution/BatchExecutionSupport.cs
@@ -27,7 +27,8 @@ internal static class BatchExecutionSupport
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(dbFilePath);
 
-        string? directoryPath = Path.GetDirectoryName(dbFilePath);
+        string resolvedDbFilePath = Path.GetFullPath(dbFilePath);
+        string? directoryPath = Path.GetDirectoryName(resolvedDbFilePath);
         if (string.IsNullOrWhiteSpace(directoryPath))
         {
             return;

--- a/SoundAnalyzer.Cli/Infrastructure/Execution/CliErrorCode.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Execution/CliErrorCode.cs
@@ -5,8 +5,12 @@ internal enum CliErrorCode
     None = 0,
     InputDirectoryNotFound,
     DbDirectoryCreationFailed,
+    DbFileRequired,
     DuplicateStftAnalysisName,
     StftTableBinCountMismatch,
     StftTableSchemaMismatch,
+    PostgresConfigurationInvalid,
+    PostgresCredentialFileNotFound,
+    PostgresSshTunnelFailed,
     UnsupportedMode,
 }

--- a/SoundAnalyzer.Cli/Infrastructure/Execution/IAnalysisStoreFactory.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Execution/IAnalysisStoreFactory.cs
@@ -1,0 +1,15 @@
+using SoundAnalyzer.Cli.Infrastructure.Sqlite;
+using SoundAnalyzer.Cli.Presentation.Cli.Arguments;
+
+namespace SoundAnalyzer.Cli.Infrastructure.Execution;
+
+internal interface IAnalysisStoreFactory
+{
+    public IPeakAnalysisStore CreatePeakStore(CommandLineArguments arguments, SqliteConflictMode conflictMode);
+
+    public IStftAnalysisStore CreateStftStore(
+        CommandLineArguments arguments,
+        string anchorColumnName,
+        int binCount,
+        SqliteConflictMode conflictMode);
+}

--- a/SoundAnalyzer.Cli/Infrastructure/Execution/IPeakAnalysisStore.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Execution/IPeakAnalysisStore.cs
@@ -1,0 +1,10 @@
+using PeakAnalyzer.Core.Application.Ports;
+
+namespace SoundAnalyzer.Cli.Infrastructure.Execution;
+
+internal interface IPeakAnalysisStore : IPeakAnalysisPointWriter, IDisposable
+{
+    public void Initialize();
+
+    public void Complete();
+}

--- a/SoundAnalyzer.Cli/Infrastructure/Execution/IStftAnalysisStore.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Execution/IStftAnalysisStore.cs
@@ -1,0 +1,10 @@
+using STFTAnalyzer.Core.Application.Ports;
+
+namespace SoundAnalyzer.Cli.Infrastructure.Execution;
+
+internal interface IStftAnalysisStore : IStftAnalysisPointWriter, IDisposable
+{
+    public void Initialize();
+
+    public void Complete();
+}

--- a/SoundAnalyzer.Cli/Infrastructure/Postgres/KnownHostsVerifier.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Postgres/KnownHostsVerifier.cs
@@ -1,0 +1,136 @@
+using System.Globalization;
+using System.Net;
+
+namespace SoundAnalyzer.Cli.Infrastructure.Postgres;
+
+internal static class KnownHostsVerifier
+{
+    public static bool IsTrusted(
+        string knownHostsPath,
+        string host,
+        int port,
+        string hostKeyAlgorithm,
+        byte[] hostKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(knownHostsPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(host);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(port);
+        ArgumentException.ThrowIfNullOrWhiteSpace(hostKeyAlgorithm);
+        ArgumentNullException.ThrowIfNull(hostKey);
+
+        string resolvedPath = Path.GetFullPath(knownHostsPath);
+        if (!File.Exists(resolvedPath))
+        {
+            return false;
+        }
+
+        string expectedKey = Convert.ToBase64String(hostKey);
+        string normalizedHost = NormalizeHost(host);
+
+        foreach (string rawLine in File.ReadAllLines(resolvedPath))
+        {
+            string line = rawLine.Trim();
+            if (line.Length == 0 || line.StartsWith('#'))
+            {
+                continue;
+            }
+
+            if (line.StartsWith('@'))
+            {
+                // Skip markers such as @cert-authority.
+                continue;
+            }
+
+            string[] tokens = line.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (tokens.Length < 3)
+            {
+                continue;
+            }
+
+            string hostPatternToken = tokens[0];
+            if (hostPatternToken.StartsWith("|1|", StringComparison.Ordinal))
+            {
+                // Hashed hosts cannot be validated without the HMAC key from OpenSSH internals.
+                continue;
+            }
+
+            if (!tokens[1].Equals(hostKeyAlgorithm, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!tokens[2].Equals(expectedKey, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            string[] hostPatterns = hostPatternToken.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            for (int i = 0; i < hostPatterns.Length; i++)
+            {
+                if (HostPatternMatches(hostPatterns[i], normalizedHost, port))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HostPatternMatches(string pattern, string host, int port)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pattern);
+        ArgumentException.ThrowIfNullOrWhiteSpace(host);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(port);
+
+        if (TryParseBracketHostAndPort(pattern, out string bracketHost, out int bracketPort))
+        {
+            return bracketPort == port && HostsEqual(bracketHost, host);
+        }
+
+        // Non-bracket host patterns in known_hosts implicitly target port 22.
+        return port == 22 && HostsEqual(pattern, host);
+    }
+
+    private static bool TryParseBracketHostAndPort(string pattern, out string host, out int port)
+    {
+        host = string.Empty;
+        port = default;
+
+        int closeBracketIndex = pattern.IndexOf(']');
+        if (pattern.Length == 0
+            || pattern[0] != '['
+            || closeBracketIndex <= 1
+            || closeBracketIndex + 2 >= pattern.Length
+            || pattern[closeBracketIndex + 1] != ':')
+        {
+            return false;
+        }
+
+        string parsedHost = pattern[1..closeBracketIndex];
+        string parsedPortText = pattern[(closeBracketIndex + 2)..];
+        if (!int.TryParse(parsedPortText, NumberStyles.None, CultureInfo.InvariantCulture, out int parsedPort)
+            || parsedPort <= 0)
+        {
+            return false;
+        }
+
+        host = NormalizeHost(parsedHost);
+        port = parsedPort;
+        return true;
+    }
+
+    private static bool HostsEqual(string left, string right)
+    {
+        return NormalizeHost(left).Equals(NormalizeHost(right), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizeHost(string host)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(host);
+        string trimmed = host.Trim();
+        return Uri.CheckHostName(trimmed) == UriHostNameType.IPv6
+            ? IPAddress.Parse(trimmed).ToString()
+            : trimmed;
+    }
+}

--- a/SoundAnalyzer.Cli/Infrastructure/Postgres/PostgresConnectionFactory.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Postgres/PostgresConnectionFactory.cs
@@ -1,0 +1,100 @@
+using Npgsql;
+using SoundAnalyzer.Cli.Infrastructure.Execution;
+
+namespace SoundAnalyzer.Cli.Infrastructure.Postgres;
+
+internal static class PostgresConnectionFactory
+{
+    public static PostgresSession OpenSession(PostgresConnectionOptions connectionOptions, PostgresSshOptions? sshOptions)
+    {
+        ArgumentNullException.ThrowIfNull(connectionOptions);
+
+        PostgresSshTunnel? tunnel = null;
+        string host = connectionOptions.Host;
+        int port = connectionOptions.Port;
+
+        if (sshOptions is not null)
+        {
+            tunnel = PostgresSshTunnelFactory.CreateTunnel(sshOptions, connectionOptions.Host, connectionOptions.Port);
+            host = tunnel.LocalHost;
+            port = tunnel.LocalPort;
+        }
+
+        NpgsqlConnectionStringBuilder builder = new()
+        {
+            Host = host,
+            Port = port,
+            Database = connectionOptions.Database,
+            Username = connectionOptions.User,
+            Timeout = 15,
+            CommandTimeout = 120,
+        };
+
+        if (!string.IsNullOrWhiteSpace(connectionOptions.Password))
+        {
+            builder.Password = connectionOptions.Password;
+        }
+
+        ConfigureSsl(builder, connectionOptions);
+
+        try
+        {
+            NpgsqlConnection connection = new(builder.ConnectionString);
+            connection.Open();
+            return new PostgresSession(connection, tunnel);
+        }
+        catch
+        {
+            tunnel?.Dispose();
+            throw;
+        }
+    }
+
+    private static void ConfigureSsl(NpgsqlConnectionStringBuilder builder, PostgresConnectionOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(options);
+
+        string? rootCertPath = ResolveOptionalExistingPath(options.SslRootCertPath);
+        string? certPath = ResolveOptionalExistingPath(options.SslCertPath);
+        string? keyPath = ResolveOptionalExistingPath(options.SslKeyPath);
+
+        bool useTls = rootCertPath is not null || certPath is not null || keyPath is not null;
+        if (!useTls)
+        {
+            return;
+        }
+
+        builder.SslMode = rootCertPath is null ? SslMode.Require : SslMode.VerifyCA;
+        if (rootCertPath is not null)
+        {
+            builder.RootCertificate = rootCertPath;
+        }
+
+        if (certPath is not null)
+        {
+            builder.SslCertificate = certPath;
+        }
+
+        if (keyPath is not null)
+        {
+            builder.SslKey = keyPath;
+        }
+    }
+
+    private static string? ResolveOptionalExistingPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        string resolvedPath = Path.GetFullPath(path);
+        if (!File.Exists(resolvedPath))
+        {
+            throw new CliException(CliErrorCode.PostgresCredentialFileNotFound, resolvedPath);
+        }
+
+        return resolvedPath;
+    }
+}

--- a/SoundAnalyzer.Cli/Infrastructure/Postgres/PostgresConnectionOptions.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Postgres/PostgresConnectionOptions.cs
@@ -1,0 +1,45 @@
+namespace SoundAnalyzer.Cli.Infrastructure.Postgres;
+
+internal sealed class PostgresConnectionOptions
+{
+    public PostgresConnectionOptions(
+        string host,
+        int port,
+        string database,
+        string user,
+        string? password,
+        string? sslCertPath,
+        string? sslKeyPath,
+        string? sslRootCertPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(host);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(port);
+        ArgumentException.ThrowIfNullOrWhiteSpace(database);
+        ArgumentException.ThrowIfNullOrWhiteSpace(user);
+
+        Host = host.Trim();
+        Port = port;
+        Database = database.Trim();
+        User = user.Trim();
+        Password = string.IsNullOrWhiteSpace(password) ? null : password;
+        SslCertPath = string.IsNullOrWhiteSpace(sslCertPath) ? null : sslCertPath.Trim();
+        SslKeyPath = string.IsNullOrWhiteSpace(sslKeyPath) ? null : sslKeyPath.Trim();
+        SslRootCertPath = string.IsNullOrWhiteSpace(sslRootCertPath) ? null : sslRootCertPath.Trim();
+    }
+
+    public string Host { get; }
+
+    public int Port { get; }
+
+    public string Database { get; }
+
+    public string User { get; }
+
+    public string? Password { get; }
+
+    public string? SslCertPath { get; }
+
+    public string? SslKeyPath { get; }
+
+    public string? SslRootCertPath { get; }
+}

--- a/SoundAnalyzer.Cli/Infrastructure/Postgres/PostgresSession.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Postgres/PostgresSession.cs
@@ -1,0 +1,29 @@
+using Npgsql;
+
+namespace SoundAnalyzer.Cli.Infrastructure.Postgres;
+
+internal sealed class PostgresSession : IDisposable
+{
+    private readonly IDisposable? disposableDependency;
+    private bool disposed;
+
+    public PostgresSession(NpgsqlConnection connection, IDisposable? disposableDependency)
+    {
+        Connection = connection ?? throw new ArgumentNullException(nameof(connection));
+        this.disposableDependency = disposableDependency;
+    }
+
+    public NpgsqlConnection Connection { get; }
+
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+        Connection.Dispose();
+        disposableDependency?.Dispose();
+    }
+}

--- a/SoundAnalyzer.Cli/Infrastructure/Postgres/PostgresSshOptions.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Postgres/PostgresSshOptions.cs
@@ -1,0 +1,34 @@
+namespace SoundAnalyzer.Cli.Infrastructure.Postgres;
+
+internal sealed class PostgresSshOptions
+{
+    public PostgresSshOptions(
+        string host,
+        int port,
+        string user,
+        string privateKeyPath,
+        string knownHostsPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(host);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(port);
+        ArgumentException.ThrowIfNullOrWhiteSpace(user);
+        ArgumentException.ThrowIfNullOrWhiteSpace(privateKeyPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(knownHostsPath);
+
+        Host = host.Trim();
+        Port = port;
+        User = user.Trim();
+        PrivateKeyPath = privateKeyPath.Trim();
+        KnownHostsPath = knownHostsPath.Trim();
+    }
+
+    public string Host { get; }
+
+    public int Port { get; }
+
+    public string User { get; }
+
+    public string PrivateKeyPath { get; }
+
+    public string KnownHostsPath { get; }
+}

--- a/SoundAnalyzer.Cli/Infrastructure/Postgres/PostgresSshTunnel.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Postgres/PostgresSshTunnel.cs
@@ -1,0 +1,63 @@
+using Renci.SshNet;
+using Renci.SshNet.Common;
+
+namespace SoundAnalyzer.Cli.Infrastructure.Postgres;
+
+internal sealed class PostgresSshTunnel : IDisposable
+{
+    private readonly SshClient sshClient;
+    private readonly ForwardedPortLocal forwardedPort;
+    private bool disposed;
+
+    public PostgresSshTunnel(SshClient sshClient, ForwardedPortLocal forwardedPort, string localHost, int localPort)
+    {
+        this.sshClient = sshClient ?? throw new ArgumentNullException(nameof(sshClient));
+        this.forwardedPort = forwardedPort ?? throw new ArgumentNullException(nameof(forwardedPort));
+        ArgumentException.ThrowIfNullOrWhiteSpace(localHost);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(localPort);
+
+        LocalHost = localHost;
+        LocalPort = localPort;
+    }
+
+    public string LocalHost { get; }
+
+    public int LocalPort { get; }
+
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+
+        try
+        {
+            if (forwardedPort.IsStarted)
+            {
+                forwardedPort.Stop();
+            }
+        }
+        catch (SshException)
+        {
+            // Best-effort stop while tearing down.
+        }
+
+        try
+        {
+            if (sshClient.IsConnected)
+            {
+                sshClient.Disconnect();
+            }
+        }
+        catch (SshException)
+        {
+            // Best-effort disconnect while tearing down.
+        }
+
+        forwardedPort.Dispose();
+        sshClient.Dispose();
+    }
+}

--- a/SoundAnalyzer.Cli/Infrastructure/Postgres/PostgresSshTunnelFactory.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Postgres/PostgresSshTunnelFactory.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using System.Net.Sockets;
+using Renci.SshNet;
+using Renci.SshNet.Common;
+using SoundAnalyzer.Cli.Infrastructure.Execution;
+
+namespace SoundAnalyzer.Cli.Infrastructure.Postgres;
+
+internal static class PostgresSshTunnelFactory
+{
+    public static PostgresSshTunnel CreateTunnel(PostgresSshOptions sshOptions, string destinationHost, int destinationPort)
+    {
+        ArgumentNullException.ThrowIfNull(sshOptions);
+        ArgumentException.ThrowIfNullOrWhiteSpace(destinationHost);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(destinationPort);
+
+        string resolvedPrivateKeyPath = Path.GetFullPath(sshOptions.PrivateKeyPath);
+        if (!File.Exists(resolvedPrivateKeyPath))
+        {
+            throw new CliException(CliErrorCode.PostgresCredentialFileNotFound, resolvedPrivateKeyPath);
+        }
+
+        string resolvedKnownHostsPath = Path.GetFullPath(sshOptions.KnownHostsPath);
+        if (!File.Exists(resolvedKnownHostsPath))
+        {
+            throw new CliException(CliErrorCode.PostgresCredentialFileNotFound, resolvedKnownHostsPath);
+        }
+
+        PrivateKeyFile keyFile;
+        try
+        {
+            keyFile = new PrivateKeyFile(resolvedPrivateKeyPath);
+        }
+        catch (Exception ex) when (ex is SshException or IOException or UnauthorizedAccessException)
+        {
+            throw new CliException(CliErrorCode.PostgresSshTunnelFailed, ex.Message, ex);
+        }
+
+        ConnectionInfo connectionInfo = new(
+            sshOptions.Host,
+            sshOptions.Port,
+            sshOptions.User,
+            new PrivateKeyAuthenticationMethod(sshOptions.User, keyFile));
+
+        SshClient sshClient = new(connectionInfo);
+        sshClient.HostKeyReceived += (_, eventArgs) =>
+        {
+            eventArgs.CanTrust = KnownHostsVerifier.IsTrusted(
+                resolvedKnownHostsPath,
+                sshOptions.Host,
+                sshOptions.Port,
+                eventArgs.HostKeyName,
+                eventArgs.HostKey);
+        };
+
+        try
+        {
+            sshClient.Connect();
+            if (!sshClient.IsConnected)
+            {
+                throw new CliException(CliErrorCode.PostgresSshTunnelFailed, "Failed to establish SSH connection.");
+            }
+
+            int localPort = FindAvailableLoopbackPort();
+            ForwardedPortLocal forwardedPort = new(
+                "127.0.0.1",
+                (uint)localPort,
+                destinationHost,
+                (uint)destinationPort);
+
+            sshClient.AddForwardedPort(forwardedPort);
+            forwardedPort.Start();
+            if (!forwardedPort.IsStarted)
+            {
+                throw new CliException(CliErrorCode.PostgresSshTunnelFailed, "Failed to start SSH local forwarding.");
+            }
+
+            return new PostgresSshTunnel(sshClient, forwardedPort, "127.0.0.1", localPort);
+        }
+        catch (SshConnectionException ex)
+        {
+            sshClient.Dispose();
+            throw new CliException(CliErrorCode.PostgresSshTunnelFailed, ex.Message, ex);
+        }
+        catch (SshAuthenticationException ex)
+        {
+            sshClient.Dispose();
+            throw new CliException(CliErrorCode.PostgresSshTunnelFailed, ex.Message, ex);
+        }
+        catch (SshOperationTimeoutException ex)
+        {
+            sshClient.Dispose();
+            throw new CliException(CliErrorCode.PostgresSshTunnelFailed, ex.Message, ex);
+        }
+        catch (CliException)
+        {
+            sshClient.Dispose();
+            throw;
+        }
+    }
+
+    private static int FindAvailableLoopbackPort()
+    {
+        using TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        IPEndPoint? endPoint = listener.LocalEndpoint as IPEndPoint;
+        return endPoint?.Port ?? throw new InvalidOperationException("Could not allocate local port.");
+    }
+}

--- a/SoundAnalyzer.Cli/Middleware/Entry.cs
+++ b/SoundAnalyzer.Cli/Middleware/Entry.cs
@@ -5,11 +5,14 @@ using Cli.Shared.Extensions;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Npgsql;
 using PeakAnalyzer.Core.Application.Errors;
 using PeakAnalyzer.Core.Extensions;
+using Renci.SshNet.Common;
 using STFTAnalyzer.Core.Application.Errors;
 using STFTAnalyzer.Core.Extensions;
 using SoundAnalyzer.Cli.Infrastructure.Execution;
+using SoundAnalyzer.Cli.Infrastructure.Postgres;
 using SoundAnalyzer.Cli.Presentation.Cli.Arguments;
 using SoundAnalyzer.Cli.Presentation.Cli.Errors;
 using SoundAnalyzer.Cli.Presentation.Cli.Texts;
@@ -90,6 +93,16 @@ internal static class Entry
             WriteErrors(new[] { CliErrorMapper.ToMessage(exception) });
             return 1;
         }
+        catch (NpgsqlException exception)
+        {
+            WriteErrors(new[] { CliErrorMapper.ToMessage(exception) });
+            return 1;
+        }
+        catch (SshException exception)
+        {
+            WriteErrors(new[] { CliErrorMapper.ToMessage(exception) });
+            return 1;
+        }
         finally
         {
             System.Console.CancelKeyPress -= cancelHandler;
@@ -125,6 +138,7 @@ internal static class Entry
         builder.Services.AddCliShared();
         builder.Services.AddPeakAnalyzerCore();
         builder.Services.AddStftAnalyzerCore();
+        builder.Services.AddSingleton<IAnalysisStoreFactory, AnalysisStoreFactory>();
         builder.Services.AddSingleton<PeakAnalysisBatchExecutor>();
         builder.Services.AddSingleton<StftAnalysisBatchExecutor>();
 

--- a/SoundAnalyzer.Cli/Presentation/Cli/Arguments/CommandLineArguments.cs
+++ b/SoundAnalyzer.Cli/Presentation/Cli/Arguments/CommandLineArguments.cs
@@ -9,7 +9,8 @@ internal sealed class CommandLineArguments
         AnalysisLengthUnit hopUnit,
         int? targetSamplingHz,
         string inputDirectoryPath,
-        string dbFilePath,
+        StorageBackend storageBackend,
+        string? dbFilePath,
         IReadOnlyList<string>? stems,
         string mode,
         string tableName,
@@ -27,12 +28,24 @@ internal sealed class CommandLineArguments
         int insertQueueSize,
         bool sqliteFastMode,
         int sqliteBatchRowCount,
-        bool showProgress)
+        bool showProgress,
+        string? postgresHost,
+        int? postgresPort,
+        string? postgresDatabase,
+        string? postgresUser,
+        string? postgresPassword,
+        string? postgresSslCertPath,
+        string? postgresSslKeyPath,
+        string? postgresSslRootCertPath,
+        string? postgresSshHost,
+        int? postgresSshPort,
+        string? postgresSshUser,
+        string? postgresSshPrivateKeyPath,
+        string? postgresSshKnownHostsPath)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(windowValue);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(hopValue);
         ArgumentException.ThrowIfNullOrWhiteSpace(inputDirectoryPath);
-        ArgumentException.ThrowIfNullOrWhiteSpace(dbFilePath);
         ArgumentException.ThrowIfNullOrWhiteSpace(mode);
         ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(stftProcThreads);
@@ -42,9 +55,24 @@ internal sealed class CommandLineArguments
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(insertQueueSize);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(sqliteBatchRowCount);
 
+        if (storageBackend == StorageBackend.Sqlite)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(dbFilePath);
+        }
+
         if (targetSamplingHz.HasValue)
         {
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(targetSamplingHz.Value);
+        }
+
+        if (postgresPort.HasValue)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(postgresPort.Value);
+        }
+
+        if (postgresSshPort.HasValue)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(postgresSshPort.Value);
         }
 
         if (double.IsNaN(minLimitDb) || double.IsInfinity(minLimitDb))
@@ -63,7 +91,8 @@ internal sealed class CommandLineArguments
         HopUnit = hopUnit;
         TargetSamplingHz = targetSamplingHz;
         InputDirectoryPath = inputDirectoryPath;
-        DbFilePath = dbFilePath;
+        StorageBackend = storageBackend;
+        DbFilePath = string.IsNullOrWhiteSpace(dbFilePath) ? null : dbFilePath.Trim();
         Stems = stems;
         Mode = mode;
         TableName = tableName;
@@ -82,6 +111,19 @@ internal sealed class CommandLineArguments
         SqliteFastMode = sqliteFastMode;
         SqliteBatchRowCount = sqliteBatchRowCount;
         ShowProgress = showProgress;
+        PostgresHost = string.IsNullOrWhiteSpace(postgresHost) ? null : postgresHost.Trim();
+        PostgresPort = postgresPort;
+        PostgresDatabase = string.IsNullOrWhiteSpace(postgresDatabase) ? null : postgresDatabase.Trim();
+        PostgresUser = string.IsNullOrWhiteSpace(postgresUser) ? null : postgresUser.Trim();
+        PostgresPassword = string.IsNullOrWhiteSpace(postgresPassword) ? null : postgresPassword;
+        PostgresSslCertPath = string.IsNullOrWhiteSpace(postgresSslCertPath) ? null : postgresSslCertPath.Trim();
+        PostgresSslKeyPath = string.IsNullOrWhiteSpace(postgresSslKeyPath) ? null : postgresSslKeyPath.Trim();
+        PostgresSslRootCertPath = string.IsNullOrWhiteSpace(postgresSslRootCertPath) ? null : postgresSslRootCertPath.Trim();
+        PostgresSshHost = string.IsNullOrWhiteSpace(postgresSshHost) ? null : postgresSshHost.Trim();
+        PostgresSshPort = postgresSshPort;
+        PostgresSshUser = string.IsNullOrWhiteSpace(postgresSshUser) ? null : postgresSshUser.Trim();
+        PostgresSshPrivateKeyPath = string.IsNullOrWhiteSpace(postgresSshPrivateKeyPath) ? null : postgresSshPrivateKeyPath.Trim();
+        PostgresSshKnownHostsPath = string.IsNullOrWhiteSpace(postgresSshKnownHostsPath) ? null : postgresSshKnownHostsPath.Trim();
     }
 
     public long WindowValue { get; }
@@ -96,7 +138,9 @@ internal sealed class CommandLineArguments
 
     public string InputDirectoryPath { get; }
 
-    public string DbFilePath { get; }
+    public StorageBackend StorageBackend { get; }
+
+    public string? DbFilePath { get; }
 
     public IReadOnlyList<string>? Stems { get; }
 
@@ -134,7 +178,35 @@ internal sealed class CommandLineArguments
 
     public bool ShowProgress { get; }
 
+    public string? PostgresHost { get; }
+
+    public int? PostgresPort { get; }
+
+    public string? PostgresDatabase { get; }
+
+    public string? PostgresUser { get; }
+
+    public string? PostgresPassword { get; }
+
+    public string? PostgresSslCertPath { get; }
+
+    public string? PostgresSslKeyPath { get; }
+
+    public string? PostgresSslRootCertPath { get; }
+
+    public string? PostgresSshHost { get; }
+
+    public int? PostgresSshPort { get; }
+
+    public string? PostgresSshUser { get; }
+
+    public string? PostgresSshPrivateKeyPath { get; }
+
+    public string? PostgresSshKnownHostsPath { get; }
+
     public bool UsesSampleUnit => WindowUnit == AnalysisLengthUnit.Sample || HopUnit == AnalysisLengthUnit.Sample;
+
+    public bool IsPostgresMode => StorageBackend == StorageBackend.Postgres;
 
     public long WindowSizeMs => WindowUnit == AnalysisLengthUnit.Millisecond
         ? WindowValue

--- a/SoundAnalyzer.Cli/Presentation/Cli/Arguments/StorageBackend.cs
+++ b/SoundAnalyzer.Cli/Presentation/Cli/Arguments/StorageBackend.cs
@@ -1,0 +1,7 @@
+namespace SoundAnalyzer.Cli.Presentation.Cli.Arguments;
+
+internal enum StorageBackend
+{
+    Sqlite = 0,
+    Postgres = 1,
+}

--- a/SoundAnalyzer.Cli/Presentation/Cli/Errors/CliErrorMapper.cs
+++ b/SoundAnalyzer.Cli/Presentation/Cli/Errors/CliErrorMapper.cs
@@ -1,6 +1,8 @@
 using AudioProcessor.Application.Errors;
 using Microsoft.Data.Sqlite;
+using Npgsql;
 using PeakAnalyzer.Core.Application.Errors;
+using Renci.SshNet.Common;
 using STFTAnalyzer.Core.Application.Errors;
 using SoundAnalyzer.Cli.Infrastructure.Execution;
 using SoundAnalyzer.Cli.Presentation.Cli.Texts;
@@ -17,9 +19,13 @@ internal static class CliErrorMapper
         {
             CliErrorCode.InputDirectoryNotFound => ConsoleTexts.WithValue(ConsoleTexts.InputDirectoryNotFoundPrefix, exception.Detail),
             CliErrorCode.DbDirectoryCreationFailed => ConsoleTexts.WithValue(ConsoleTexts.FailedToCreateDbDirectoryPrefix, exception.Detail),
+            CliErrorCode.DbFileRequired => ConsoleTexts.WithValue(ConsoleTexts.DbFileRequiredPrefix, exception.Detail),
             CliErrorCode.DuplicateStftAnalysisName => ConsoleTexts.WithValue(ConsoleTexts.DuplicateStftAnalysisNamePrefix, exception.Detail),
             CliErrorCode.StftTableBinCountMismatch => ConsoleTexts.WithValue(ConsoleTexts.StftBinCountMismatchPrefix, exception.Detail),
             CliErrorCode.StftTableSchemaMismatch => ConsoleTexts.WithValue(ConsoleTexts.StftSchemaMismatchPrefix, exception.Detail),
+            CliErrorCode.PostgresConfigurationInvalid => ConsoleTexts.WithValue(ConsoleTexts.PostgresConfigurationInvalidPrefix, exception.Detail),
+            CliErrorCode.PostgresCredentialFileNotFound => ConsoleTexts.WithValue(ConsoleTexts.PostgresCredentialFileNotFoundPrefix, exception.Detail),
+            CliErrorCode.PostgresSshTunnelFailed => ConsoleTexts.WithValue(ConsoleTexts.PostgresSshTunnelFailedPrefix, exception.Detail),
             CliErrorCode.UnsupportedMode => ConsoleTexts.WithValue(ConsoleTexts.InvalidModePrefix, exception.Detail),
             _ => exception.Detail,
         };
@@ -74,5 +80,17 @@ internal static class CliErrorMapper
     {
         ArgumentNullException.ThrowIfNull(exception);
         return ConsoleTexts.WithValue(ConsoleTexts.DatabaseOperationFailedPrefix, exception.Message);
+    }
+
+    public static string ToMessage(NpgsqlException exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        return ConsoleTexts.WithValue(ConsoleTexts.PostgresOperationFailedPrefix, exception.Message);
+    }
+
+    public static string ToMessage(SshException exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        return ConsoleTexts.WithValue(ConsoleTexts.PostgresSshTunnelFailedPrefix, exception.Message);
     }
 }

--- a/SoundAnalyzer.Cli/Presentation/Cli/Texts/ConsoleTexts.cs
+++ b/SoundAnalyzer.Cli/Presentation/Cli/Texts/ConsoleTexts.cs
@@ -27,6 +27,20 @@ internal static class ConsoleTexts
     public const string SqliteBatchRowCountOption = "--sqlite-batch-row-count";
     public const string FfmpegPathOption = "--ffmpeg-path";
     public const string ShowProgressOption = "--show-progress";
+    public const string PostgresOption = "--postgres";
+    public const string PostgresHostOption = "--postgres-host";
+    public const string PostgresPortOption = "--postgres-port";
+    public const string PostgresDbOption = "--postgres-db";
+    public const string PostgresUserOption = "--postgres-user";
+    public const string PostgresPasswordOption = "--postgres-password";
+    public const string PostgresSslCertPathOption = "--postgres-sslcert-path";
+    public const string PostgresSslKeyPathOption = "--postgres-sslkey-path";
+    public const string PostgresSslRootCertPathOption = "--postgres-sslrootcert-path";
+    public const string PostgresSshHostOption = "--postgres-ssh-host";
+    public const string PostgresSshPortOption = "--postgres-ssh-port";
+    public const string PostgresSshUserOption = "--postgres-ssh-user";
+    public const string PostgresSshPrivateKeyPathOption = "--postgres-ssh-private-key-path";
+    public const string PostgresSshKnownHostsPathOption = "--postgres-ssh-known-hosts-path";
     public const string HelpOption = "--help";
     public const string ShortHelpOption = "-h";
 
@@ -39,14 +53,41 @@ internal static class ConsoleTexts
     public const string HelpText =
 """
 Usage:
-  SoundAnalyzer.Cli.exe --window-size <len> --hop <len> --input-dir <path> --db-file <path> --mode <peak-analysis|stft-analysis> [options]
+  SoundAnalyzer.Cli.exe --window-size <len> --hop <len> --input-dir <path> --mode <peak-analysis|stft-analysis> [--db-file <path> | --postgres ...] [options]
 
 Required options:
   --window-size <len>       Analysis window size (ms/s/m/sample/samples)
   --hop <len>               Hop size (ms/s/m/sample/samples)
   --input-dir <path>        Input root directory
-  --db-file <path>          SQLite db file path
   --mode <value>            peak-analysis or stft-analysis
+
+Storage backend:
+  (default: SQLite)
+  --db-file <path>          SQLite db file path
+  --postgres                Enable PostgreSQL storage backend
+
+PostgreSQL connection options (required with --postgres):
+  --postgres-host <host>    PostgreSQL host
+  --postgres-port <port>    PostgreSQL port
+  --postgres-db <name>      PostgreSQL database name
+  --postgres-user <user>    PostgreSQL user
+  --postgres-password <pw>  PostgreSQL password (exclusive with ssl cert/key auth)
+  --postgres-sslcert-path <path>
+                            PostgreSQL client certificate path (requires sslkey-path)
+  --postgres-sslkey-path <path>
+                            PostgreSQL client private key path (requires sslcert-path)
+  --postgres-sslrootcert-path <path>
+                            PostgreSQL root CA certificate path (optional)
+  --postgres-ssh-host <host>
+                            Enable SSH tunnel to PostgreSQL automatically
+  --postgres-ssh-port <port>
+                            SSH port (default: 22)
+  --postgres-ssh-user <user>
+                            SSH user (required with postgres-ssh-host)
+  --postgres-ssh-private-key-path <path>
+                            SSH private key file path (required with postgres-ssh-host)
+  --postgres-ssh-known-hosts-path <path>
+                            SSH known_hosts file path (required with postgres-ssh-host)
 
 Optional:
   --target-sampling <n>hz   Required when window/hop uses sample(s) in stft mode
@@ -63,16 +104,16 @@ Optional:
   --stft-file-threads <n>   STFT mode only. Number of files analyzed in parallel (default: 1)
   --peak-file-threads <n>   Peak mode only. Number of songs analyzed in parallel (default: 1)
   --insert-queue-size <n>   Bounded queue size between analyze and DB insert (default: 1024)
-  --sqlite-fast-mode        Enable SQLite write-speed PRAGMA tuning (durability trade-off)
+  --sqlite-fast-mode        SQLite mode only. Enable write-speed PRAGMA tuning (durability trade-off)
   --sqlite-batch-row-count <n>
-                            SQLite multi-row INSERT batch size (default: 512)
+                            SQLite mode only. Multi-row INSERT batch size (default: 512)
   --ffmpeg-path <path>      ffmpeg executable path or directory containing ffmpeg/ffprobe
   --show-progress           Show advanced progress UI on interactive stderr
   --help, -h                Show help
 
 Examples:
   SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --mode peak-analysis --stems Piano,Drums --peak-file-threads 2 --peak-proc-threads 4 --insert-queue-size 2048 --show-progress
-  SoundAnalyzer.Cli.exe --window-size 2048samples --hop 512samples --target-sampling 44100hz --input-dir /path/to/dir --db-file /path/to/file.db --mode stft-analysis --bin-count 12 --stft-file-threads 2 --stft-proc-threads 6 --insert-queue-size 4096 --show-progress
+  SoundAnalyzer.Cli.exe --window-size 2048samples --hop 512samples --target-sampling 44100hz --input-dir /path/to/dir --mode stft-analysis --bin-count 12 --postgres --postgres-host localhost --postgres-port 5432 --postgres-db audio --postgres-user analyzer --postgres-password secret --stft-file-threads 2 --stft-proc-threads 6 --insert-queue-size 4096 --show-progress
 """;
 
     public const string MissingOptionPrefix = "Missing required option: ";
@@ -88,13 +129,24 @@ Examples:
     public const string UpsertSkipConflictText = "--upsert and --skip-duplicate cannot be specified together.";
     public const string SampleUnitOnlyForStftText = "sample/sample(s) units are only supported with --mode stft-analysis.";
     public const string IncompatibleOptionIgnoredPrefix = "Option is ignored for current mode: ";
+    public const string PostgresOptionRequiresPostgresModePrefix = "Option requires --postgres mode: ";
+    public const string SqliteOptionNotAllowedWithPostgresPrefix = "SQLite option is not allowed with --postgres: ";
+    public const string PostgresAuthConflictText = "--postgres-password and --postgres-sslcert-path/--postgres-sslkey-path cannot be used together.";
+    public const string PostgresSslPairRequiredText = "--postgres-sslcert-path and --postgres-sslkey-path must be specified together.";
+    public const string PostgresDbFileConflictText = "--db-file cannot be used with --postgres.";
+    public const string PostgresAuthNotProvidedWarningText = "PostgreSQL auth material is not specified; attempting connection without password/client certificate.";
 
     public const string InputDirectoryNotFoundPrefix = "Input directory does not exist: ";
     public const string FailedToCreateDbDirectoryPrefix = "Failed to create db directory: ";
+    public const string DbFileRequiredPrefix = "SQLite mode requires --db-file: ";
     public const string DuplicateStftAnalysisNamePrefix = "Duplicate analysis name in input set (case-insensitive): ";
     public const string StftBinCountMismatchPrefix = "Existing STFT table bin-count mismatch: ";
     public const string StftSchemaMismatchPrefix = "Existing STFT table schema mismatch: ";
     public const string DatabaseOperationFailedPrefix = "Database operation failed: ";
+    public const string PostgresOperationFailedPrefix = "PostgreSQL operation failed: ";
+    public const string PostgresCredentialFileNotFoundPrefix = "PostgreSQL credential file was not found: ";
+    public const string PostgresSshTunnelFailedPrefix = "SSH tunnel operation failed: ";
+    public const string PostgresConfigurationInvalidPrefix = "PostgreSQL configuration is invalid: ";
     public const string OperationCanceledText = "Operation was canceled.";
 
     public const string FfmpegNotFoundPrefix = "ffmpeg was not found or not executable: ";

--- a/SoundAnalyzer.Cli/README.md
+++ b/SoundAnalyzer.Cli/README.md
@@ -1,7 +1,7 @@
 # SoundAnalyzer.Cli
 
 ## 役割
-`SoundAnalyzer.Cli` はディレクトリ配下の音声ファイルを一括解析し、結果を SQLite へ保存する CLI です。  
+`SoundAnalyzer.Cli` はディレクトリ配下の音声ファイルを一括解析し、結果を SQLite / PostgreSQL へ保存する CLI です。  
 `peak-analysis` は `PeakAnalyzer.Core`、`stft-analysis` は `STFTAnalyzer.Core` を利用します。
 
 Windows / Linux は必須サポート対象です（SQLite モード・Postgres モードの双方で同一方針を適用します）。
@@ -10,11 +10,11 @@ macOS は任意検証対象です。
 ## 実行形式
 
 ```powershell
-SoundAnalyzer.Cli.exe --window-size <len> --hop <len> --input-dir <path> --db-file <path> --mode <peak-analysis|stft-analysis> [options]
+SoundAnalyzer.Cli.exe --window-size <len> --hop <len> --input-dir <path> --mode <peak-analysis|stft-analysis> [--db-file <path> | --postgres ...] [options]
 ```
 
 ```bash
-dotnet SoundAnalyzer.Cli.dll --window-size <len> --hop <len> --input-dir <path> --db-file <path> --mode <peak-analysis|stft-analysis> [options]
+dotnet SoundAnalyzer.Cli.dll --window-size <len> --hop <len> --input-dir <path> --mode <peak-analysis|stft-analysis> [--db-file <path> | --postgres ...] [options]
 ```
 
 ## クロスプラットフォーム方針
@@ -30,7 +30,21 @@ dotnet SoundAnalyzer.Cli.dll --window-size <len> --hop <len> --input-dir <path> 
 | `--window-size <len>` | 必須 | 解析窓サイズ。`ms/s/m/sample/samples` を受理（整数値へ変換可能であること） |
 | `--hop <len>` | 必須 | hop。`ms/s/m/sample/samples` を受理（整数値へ変換可能であること） |
 | `--input-dir <path>` | 必須 | 入力ルート |
-| `--db-file <path>` | 必須 | SQLite ファイル |
+| `--db-file <path>` | 条件付き必須 | SQLite モード時に必須（`--postgres` 指定時は指定不可） |
+| `--postgres` | 任意 | PostgreSQL モードを有効化 |
+| `--postgres-host <host>` | 条件付き必須 | `--postgres` 指定時に必須 |
+| `--postgres-port <port>` | 条件付き必須 | `--postgres` 指定時に必須 |
+| `--postgres-db <name>` | 条件付き必須 | `--postgres` 指定時に必須 |
+| `--postgres-user <user>` | 条件付き必須 | `--postgres` 指定時に必須 |
+| `--postgres-password <pw>` | 任意 | パスワード認証。`sslcert+sslkey` と排他 |
+| `--postgres-sslcert-path <path>` | 任意 | クライアント証明書。`sslkey` と同時指定必須 |
+| `--postgres-sslkey-path <path>` | 任意 | クライアント秘密鍵。`sslcert` と同時指定必須 |
+| `--postgres-sslrootcert-path <path>` | 任意 | ルート証明書（CA） |
+| `--postgres-ssh-host <host>` | 任意 | 指定時に SSH トンネルを自動有効化 |
+| `--postgres-ssh-port <port>` | 任意 | SSH ポート（既定 `22`） |
+| `--postgres-ssh-user <user>` | 条件付き必須 | `--postgres-ssh-host` 指定時に必須 |
+| `--postgres-ssh-private-key-path <path>` | 条件付き必須 | `--postgres-ssh-host` 指定時に必須 |
+| `--postgres-ssh-known-hosts-path <path>` | 条件付き必須 | `--postgres-ssh-host` 指定時に必須 |
 | `--mode <value>` | 必須 | `peak-analysis` または `stft-analysis` |
 | `--target-sampling <n>hz` | 条件付き必須 | `stft-analysis` かつ `window/hop` のどちらかが `sample(s)` 指定の場合に必須 |
 | `--table-name-override <name>` | 任意 | テーブル名上書き |
@@ -45,8 +59,8 @@ dotnet SoundAnalyzer.Cli.dll --window-size <len> --hop <len> --input-dir <path> 
 | `--stft-file-threads <n>` | 任意 | `stft-analysis` のみ。同時解析ファイル数（既定 `1`） |
 | `--peak-file-threads <n>` | 任意 | `peak-analysis` のみ。同時解析 Song 数（既定 `1`） |
 | `--insert-queue-size <n>` | 任意 | 解析と DB Insert の間に置く bounded queue の容量（既定 `1024`） |
-| `--sqlite-batch-row-count <n>` | 任意 | SQLite の複数行 INSERT バッチ行数（既定 `512`、SQLite変数上限で自動クランプ） |
-| `--sqlite-fast-mode` | 任意 | SQLite 書込PRAGMAを速度優先へ切替（`synchronous=OFF` 等、耐障害性トレードオフあり） |
+| `--sqlite-batch-row-count <n>` | 任意 | SQLite モード専用。複数行 INSERT バッチ行数（既定 `512`、SQLite変数上限で自動クランプ） |
+| `--sqlite-fast-mode` | 任意 | SQLite モード専用。書込PRAGMAを速度優先へ切替（`synchronous=OFF` 等、耐障害性トレードオフあり） |
 | `--stems <csv>` | 任意 | `peak-analysis` のみ。解析対象 stem |
 | `--ffmpeg-path <path>` | 任意 | 音声処理ツールのパス指定（現行実装では ffmpeg/ffprobe） |
 | `--show-progress` | 任意 | 対話端末で詳細進捗表示（Songs/Threads/Queue）を有効化（`stderr` 出力）。Thread行は単一ゲージ（Insert=緑、Analyze-only=白、未処理=斑点） |
@@ -59,6 +73,19 @@ dotnet SoundAnalyzer.Cli.dll --window-size <len> --hop <len> --input-dir <path> 
 - `sample(s)` を1つでも使う場合は `--target-sampling <n>hz` が必須です（例: `44100hz`）。
 - モード不一致オプションはエラーではなく warning として無視されます（`stderr` に JSON の `warnings` を出力）。
 - 互換性注意: `--progress` は廃止され、`--show-progress` のみ受理します。
+
+### Storage バックエンド切替規則
+
+- 既定は SQLite モードです。
+- `--postgres` 指定時のみ PostgreSQL モードに切り替わります。
+- PostgreSQL モード時は `--db-file` を指定できません。
+- PostgreSQL モード時は `--sqlite-fast-mode` / `--sqlite-batch-row-count` を指定できません。
+- SQLite モード時に PostgreSQL 専用オプションを指定するとエラーになります。
+- PostgreSQL 認証は `--postgres-password` と `--postgres-sslcert-path + --postgres-sslkey-path` が排他です。
+- `sslcert` と `sslkey` は同時指定必須です（片側のみはエラー）。
+- 認証情報が未指定の場合は warning を出して接続試行を継続します。
+- `--postgres-ssh-host` 指定時は SSH トンネルを自動有効化します。
+- SSH 有効時は `ssh-user` / `ssh-private-key-path` / `ssh-known-hosts-path` が必須です。
 
 ### `--show-progress` 表示仕様
 
@@ -129,6 +156,14 @@ dotnet SoundAnalyzer.Cli.dll --window-size <len> --hop <len> --input-dir <path> 
 旧 wide 形式（`bin001..binNNN` 列）の STFT テーブルを検知した場合は互換実行せず失敗します。  
 その場合は `--delete-current` で再作成するか、`--table-name-override` で新規テーブルを指定してください。
 
+## PostgreSQL スキーマ
+
+- SQLite と同じ論理列を維持します（Peak: `idx,name,stem,window,ms,db,create_at,modified_at` / STFT: `idx,name,ch,window,ms|sample,bin_no,db,create_at,modified_at`）。
+- 競合モードは SQLite と同等です（Error / Upsert / SkipDuplicate）。
+- 既存テーブル時の STFT スキーマ検証 / bin-count 検証 / `--delete-current` 挙動は SQLite と同等です。
+- インデックスは SQLite 相当を基本とし、STFT では PostgreSQL 向けに `(name, ch, window, anchor)` 補助インデックスを明示作成します。
+- PostgreSQL 側も複数行 `INSERT ... VALUES` バッチで挿入します（内部既定 `512`）。
+
 ## 音声処理の扱い
 
 - 解析は `pcm_f32le` で実施します。
@@ -177,4 +212,16 @@ SoundAnalyzer.Cli.exe --window-size 2048samples --hop 512samples --target-sampli
 
 ```bash
 dotnet SoundAnalyzer.Cli.dll --window-size 2048samples --hop 512samples --target-sampling 44100hz --input-dir /path/to/dir --db-file /path/to/file.db --mode stft-analysis --bin-count 24 --upsert
+```
+
+### PostgreSQL 実行例（Windows, password 認証）
+
+```powershell
+SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir C:\audio\split --mode stft-analysis --bin-count 24 --postgres --postgres-host 127.0.0.1 --postgres-port 5432 --postgres-db audio --postgres-user analyzer --postgres-password secret --table-name-override T_STFT --upsert --show-progress
+```
+
+### PostgreSQL 実行例（Linux, SSH トンネル）
+
+```bash
+dotnet SoundAnalyzer.Cli.dll --window-size 50ms --hop 10ms --input-dir /data/audio/split --mode peak-analysis --postgres --postgres-host 10.0.0.12 --postgres-port 5432 --postgres-db audio --postgres-user analyzer --postgres-password secret --postgres-ssh-host bastion.example.com --postgres-ssh-user ubuntu --postgres-ssh-private-key-path /home/ubuntu/.ssh/id_ed25519 --postgres-ssh-known-hosts-path /home/ubuntu/.ssh/known_hosts --show-progress
 ```

--- a/SoundAnalyzer.Cli/SoundAnalyzer.Cli.csproj
+++ b/SoundAnalyzer.Cli/SoundAnalyzer.Cli.csproj
@@ -18,6 +18,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="Npgsql" />
+    <PackageReference Include="SSH.NET" />
   </ItemGroup>
 
   <ItemGroup>

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -15,6 +15,8 @@
 | Microsoft.Extensions.DependencyInjection | 10.0.3 | MIT | `AudioProcessor`, `AudioSplitter.Core`, `PeakAnalyzer.Core`, `AudioSplitter.Cli`, `SoundAnalyzer.Cli` | DI コンテナ |
 | Microsoft.Extensions.Hosting | 10.0.3 | MIT | `AudioSplitter.Cli`, `SoundAnalyzer.Cli` | Host 構成 |
 | Microsoft.Data.Sqlite | 10.0.0 | MIT | `SoundAnalyzer.Cli` | SQLite アクセス |
+| Npgsql | 8.0.4 | PostgreSQL License | `SoundAnalyzer.Cli` | PostgreSQL アクセス |
+| SSH.NET | 2024.2.0 | MIT | `SoundAnalyzer.Cli` | SSH トンネル接続 |
 | NAudio | 2.2.1 | MIT（license.txt） | `AudioSplitter.Cli` | 音声関連ユーティリティ |
 | OpenTK.Audio.OpenAL | 4.9.4 | MIT | `AudioSplitter.Cli` | OpenAL バインディング |
 

--- a/build-logs/2026-02-25T031302-issue23-postgres-build.txt
+++ b/build-logs/2026-02-25T031302-issue23-postgres-build.txt
@@ -1,0 +1,22 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+
+ビルドに成功しました。
+    0 個の警告
+    0 エラー
+
+経過時間 00:00:03.04

--- a/build-logs/2026-02-25T031312-issue23-postgres-test.txt
+++ b/build-logs/2026-02-25T031312-issue23-postgres-test.txt
@@ -1,0 +1,65 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+VSTest のバージョン 18.0.1 (x64)
+
+
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+テスト実行を開始しています。お待ちください...
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+テスト実行を開始しています。お待ちください...
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+VSTest のバージョン 18.0.1 (x64)
+
+VSTest のバージョン 18.0.1 (x64)
+
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+テスト実行を開始しています。お待ちください...
+C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:    12、スキップ:     0、合計:    12、期間: 85 ms - AudioProcessor.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    21、スキップ:     0、合計:    21、期間: 191 ms - Cli.Shared.Tests.dll (net10.0)
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:     7、スキップ:     0、合計:     7、期間: 300 ms - STFTAnalyzer.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:     8、スキップ:     0、合計:     8、期間: 85 ms - AudioSplitter.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:     5、スキップ:     0、合計:     5、期間: 83 ms - PeakAnalyzer.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    15、スキップ:     0、合計:    15、期間: 85 ms - AudioSplitter.Cli.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    81、スキップ:     0、合計:    81、期間: 2 s - SoundAnalyzer.Cli.Tests.dll (net10.0)


### PR DESCRIPTION
## Summary
- add SQLite/Postgres backend switching (`--postgres`) to SoundAnalyzer.Cli
- implement PostgreSQL stores for Peak/STFT with conflict modes (Error/Upsert/SkipDuplicate)
- add PostgreSQL connection/authentication/SSH tunnel handling with known_hosts verification
- introduce store factory abstraction and wire executors to backend-agnostic stores
- expand CLI validation, help texts, docs, and third-party notices for Postgres support
- add parser and PostgreSQL integration tests (env-guarded)

## Validation
- `dotnet build AudioProcessor.slnx -warnaserror`
- `dotnet test AudioProcessor.slnx`

Fixes #23