### PR TITLE
Add --postgres-batch-row-count to SoundAnalyzer.Cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ AudioProcessor は、オーディオ解析・変換ツール群を提供する .
   - STFT bin は `bin_no` / `db` の縦持ち行として保存（列数上限依存を回避）
   - `--stft-proc-threads` / `--stft-file-threads` / `--insert-queue-size` で並列・キュー制御
   - 大量投入向けに `--sqlite-batch-row-count`（既定 `512`）で複数行 INSERT バッチサイズを調整可能
+  - PostgreSQLモードでは `--postgres-batch-row-count`（既定 `1`）で複数行 INSERT バッチサイズを調整可能（上限は自動クランプ）
   - `--sqlite-fast-mode` 指定時のみ SQLite 書込PRAGMAを速度優先へ切替（耐障害性トレードオフあり）
 - `--show-progress` は interactive な `pwsh/cmd` で、Songs/Threads/Queue の詳細進捗を `stderr` に表示（Thread行は単一ゲージで Insert=緑 / Analyze=白 / 未処理=斑点）
 
@@ -134,7 +135,7 @@ dotnet SoundAnalyzer.Cli.dll --window-size 50ms --hop 10ms --input-dir /data/aud
 ### SoundAnalyzer.Cli (PostgreSQL 実行例)
 
 ```powershell
-SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir C:\audio\split --mode stft-analysis --bin-count 12 --postgres --postgres-host 127.0.0.1 --postgres-port 5432 --postgres-db audio --postgres-user analyzer --postgres-password secret --show-progress
+SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir C:\audio\split --mode stft-analysis --bin-count 12 --postgres --postgres-host 127.0.0.1 --postgres-port 5432 --postgres-db audio --postgres-user analyzer --postgres-password secret --postgres-batch-row-count 512 --show-progress
 ```
 
 ## ライセンス

--- a/SoundAnalyzer.Cli.Tests/Infrastructure/Postgres/PostgresBatchSizeCalculatorTests.cs
+++ b/SoundAnalyzer.Cli.Tests/Infrastructure/Postgres/PostgresBatchSizeCalculatorTests.cs
@@ -1,0 +1,54 @@
+using SoundAnalyzer.Cli.Infrastructure.Postgres;
+
+namespace SoundAnalyzer.Cli.Tests.Infrastructure.Postgres;
+
+public sealed class PostgresBatchSizeCalculatorTests
+{
+    [Fact]
+    public void ResolveEffectiveBatchRowCount_ShouldReturnRequested_WhenWithinLimit()
+    {
+        int actual = PostgresBatchSizeCalculator.ResolveEffectiveBatchRowCount(
+            requestedBatchRowCount: 5_000,
+            columnsPerRow: 8);
+
+        Assert.Equal(5_000, actual);
+    }
+
+    [Fact]
+    public void ResolveEffectiveBatchRowCount_ShouldClampByParameterLimit_ForPeakColumns()
+    {
+        int actual = PostgresBatchSizeCalculator.ResolveEffectiveBatchRowCount(
+            requestedBatchRowCount: 100_000,
+            columnsPerRow: 7);
+
+        Assert.Equal(9_362, actual);
+    }
+
+    [Fact]
+    public void ResolveEffectiveBatchRowCount_ShouldClampByParameterLimit_ForStftColumns()
+    {
+        int actual = PostgresBatchSizeCalculator.ResolveEffectiveBatchRowCount(
+            requestedBatchRowCount: 100_000,
+            columnsPerRow: 8);
+
+        Assert.Equal(8_191, actual);
+    }
+
+    [Fact]
+    public void ResolveEffectiveBatchRowCount_ShouldThrow_WhenRequestedBatchRowCountIsNotPositive()
+    {
+        _ = Assert.Throws<ArgumentOutOfRangeException>(
+            () => PostgresBatchSizeCalculator.ResolveEffectiveBatchRowCount(
+                requestedBatchRowCount: 0,
+                columnsPerRow: 8));
+    }
+
+    [Fact]
+    public void ResolveEffectiveBatchRowCount_ShouldThrow_WhenColumnsPerRowIsNotPositive()
+    {
+        _ = Assert.Throws<ArgumentOutOfRangeException>(
+            () => PostgresBatchSizeCalculator.ResolveEffectiveBatchRowCount(
+                requestedBatchRowCount: 1,
+                columnsPerRow: 0));
+    }
+}

--- a/SoundAnalyzer.Cli/Infrastructure/Execution/AnalysisStoreFactory.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Execution/AnalysisStoreFactory.cs
@@ -16,7 +16,8 @@ internal sealed class AnalysisStoreFactory : IAnalysisStoreFactory
                 BuildPostgresConnectionOptions(arguments),
                 BuildPostgresSshOptions(arguments),
                 arguments.TableName,
-                conflictMode),
+                conflictMode,
+                arguments.PostgresBatchRowCount),
             _ => new SqlitePeakAnalysisStore(
                 arguments.DbFilePath ?? throw new CliException(CliErrorCode.DbFileRequired, "SQLite mode requires db file path."),
                 arguments.TableName,
@@ -44,7 +45,8 @@ internal sealed class AnalysisStoreFactory : IAnalysisStoreFactory
                 anchorColumnName,
                 conflictMode,
                 binCount,
-                arguments.DeleteCurrent),
+                arguments.DeleteCurrent,
+                arguments.PostgresBatchRowCount),
             _ => new SqliteStftAnalysisStore(
                 arguments.DbFilePath ?? throw new CliException(CliErrorCode.DbFileRequired, "SQLite mode requires db file path."),
                 arguments.TableName,

--- a/SoundAnalyzer.Cli/Infrastructure/Postgres/PostgresBatchSizeCalculator.cs
+++ b/SoundAnalyzer.Cli/Infrastructure/Postgres/PostgresBatchSizeCalculator.cs
@@ -1,0 +1,15 @@
+namespace SoundAnalyzer.Cli.Infrastructure.Postgres;
+
+internal static class PostgresBatchSizeCalculator
+{
+    private const int MaxParameterCount = 65_535;
+
+    public static int ResolveEffectiveBatchRowCount(int requestedBatchRowCount, int columnsPerRow)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(requestedBatchRowCount);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(columnsPerRow);
+
+        int maxRowsByParameterLimit = Math.Max(1, MaxParameterCount / columnsPerRow);
+        return Math.Min(requestedBatchRowCount, maxRowsByParameterLimit);
+    }
+}

--- a/SoundAnalyzer.Cli/Presentation/Cli/Arguments/CommandLineArguments.cs
+++ b/SoundAnalyzer.Cli/Presentation/Cli/Arguments/CommandLineArguments.cs
@@ -31,6 +31,7 @@ internal sealed class CommandLineArguments
         bool showProgress,
         string? postgresHost,
         int? postgresPort,
+        int postgresBatchRowCount,
         string? postgresDatabase,
         string? postgresUser,
         string? postgresPassword,
@@ -69,6 +70,8 @@ internal sealed class CommandLineArguments
         {
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(postgresPort.Value);
         }
+
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(postgresBatchRowCount);
 
         if (postgresSshPort.HasValue)
         {
@@ -113,6 +116,7 @@ internal sealed class CommandLineArguments
         ShowProgress = showProgress;
         PostgresHost = string.IsNullOrWhiteSpace(postgresHost) ? null : postgresHost.Trim();
         PostgresPort = postgresPort;
+        PostgresBatchRowCount = postgresBatchRowCount;
         PostgresDatabase = string.IsNullOrWhiteSpace(postgresDatabase) ? null : postgresDatabase.Trim();
         PostgresUser = string.IsNullOrWhiteSpace(postgresUser) ? null : postgresUser.Trim();
         PostgresPassword = string.IsNullOrWhiteSpace(postgresPassword) ? null : postgresPassword;
@@ -181,6 +185,8 @@ internal sealed class CommandLineArguments
     public string? PostgresHost { get; }
 
     public int? PostgresPort { get; }
+
+    public int PostgresBatchRowCount { get; }
 
     public string? PostgresDatabase { get; }
 

--- a/SoundAnalyzer.Cli/Presentation/Cli/Arguments/CommandLineParser.cs
+++ b/SoundAnalyzer.Cli/Presentation/Cli/Arguments/CommandLineParser.cs
@@ -10,6 +10,7 @@ internal static partial class CommandLineParser
     private const int DefaultFileThreads = 1;
     private const int DefaultInsertQueueSize = 1024;
     private const int DefaultSqliteBatchRowCount = 512;
+    private const int DefaultPostgresBatchRowCount = 1;
     private const int DefaultPostgresSshPort = 22;
 
     public static CommandLineParseResult Parse(IReadOnlyList<string> args)
@@ -40,6 +41,7 @@ internal static partial class CommandLineParser
         string? sqliteBatchRowCountText = null;
         string? postgresHostText = null;
         string? postgresPortText = null;
+        string? postgresBatchRowCountText = null;
         string? postgresDbText = null;
         string? postgresUserText = null;
         string? postgresPasswordText = null;
@@ -312,6 +314,16 @@ internal static partial class CommandLineParser
                 continue;
             }
 
+            if (MatchesOption(token, ConsoleTexts.PostgresBatchRowCountOption))
+            {
+                if (TryReadOptionValue(args, ref i, token, errors, out string value))
+                {
+                    postgresBatchRowCountText = value;
+                }
+
+                continue;
+            }
+
             if (MatchesOption(token, ConsoleTexts.PostgresUserOption))
             {
                 if (TryReadOptionValue(args, ref i, token, errors, out string value))
@@ -447,6 +459,7 @@ internal static partial class CommandLineParser
 
         bool hasPostgresHost = IsSpecified(postgresHostText);
         bool hasPostgresPort = IsSpecified(postgresPortText);
+        bool hasPostgresBatchRowCount = IsSpecified(postgresBatchRowCountText);
         bool hasPostgresDb = IsSpecified(postgresDbText);
         bool hasPostgresUser = IsSpecified(postgresUserText);
         bool hasPostgresPassword = IsSpecified(postgresPasswordText);
@@ -463,6 +476,7 @@ internal static partial class CommandLineParser
         [
             hasPostgresHost ? ConsoleTexts.PostgresHostOption : string.Empty,
             hasPostgresPort ? ConsoleTexts.PostgresPortOption : string.Empty,
+            hasPostgresBatchRowCount ? ConsoleTexts.PostgresBatchRowCountOption : string.Empty,
             hasPostgresDb ? ConsoleTexts.PostgresDbOption : string.Empty,
             hasPostgresUser ? ConsoleTexts.PostgresUserOption : string.Empty,
             hasPostgresPassword ? ConsoleTexts.PostgresPasswordOption : string.Empty,
@@ -710,6 +724,19 @@ internal static partial class CommandLineParser
             }
         }
 
+        int postgresBatchRowCount = DefaultPostgresBatchRowCount;
+        if (!string.IsNullOrWhiteSpace(postgresBatchRowCountText))
+        {
+            if (!TryParsePositiveInt(postgresBatchRowCountText!, out int parsedPostgresBatchRowCount))
+            {
+                errors.Add(ConsoleTexts.WithValue(ConsoleTexts.InvalidIntegerPrefix, postgresBatchRowCountText!));
+            }
+            else
+            {
+                postgresBatchRowCount = parsedPostgresBatchRowCount;
+            }
+        }
+
         int? postgresSshPort = null;
         if (!string.IsNullOrWhiteSpace(postgresSshPortText))
         {
@@ -863,6 +890,7 @@ internal static partial class CommandLineParser
             showProgress,
             postgresHostText,
             postgresPort,
+            postgresBatchRowCount,
             postgresDbText,
             postgresUserText,
             postgresPasswordText,

--- a/SoundAnalyzer.Cli/Presentation/Cli/Texts/ConsoleTexts.cs
+++ b/SoundAnalyzer.Cli/Presentation/Cli/Texts/ConsoleTexts.cs
@@ -41,6 +41,7 @@ internal static class ConsoleTexts
     public const string PostgresSshUserOption = "--postgres-ssh-user";
     public const string PostgresSshPrivateKeyPathOption = "--postgres-ssh-private-key-path";
     public const string PostgresSshKnownHostsPathOption = "--postgres-ssh-known-hosts-path";
+    public const string PostgresBatchRowCountOption = "--postgres-batch-row-count";
     public const string HelpOption = "--help";
     public const string ShortHelpOption = "-h";
 
@@ -88,6 +89,8 @@ PostgreSQL connection options (required with --postgres):
                             SSH private key file path (required with postgres-ssh-host)
   --postgres-ssh-known-hosts-path <path>
                             SSH known_hosts file path (required with postgres-ssh-host)
+  --postgres-batch-row-count <n>
+                            PostgreSQL mode only. Multi-row INSERT batch size (default: 1)
 
 Optional:
   --target-sampling <n>hz   Required when window/hop uses sample(s) in stft mode

--- a/build-logs/2026-02-25T061022-issue27-postgres-batch-build.txt
+++ b/build-logs/2026-02-25T061022-issue27-postgres-batch-build.txt
@@ -1,0 +1,22 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+
+ビルドに成功しました。
+    0 個の警告
+    0 エラー
+
+経過時間 00:00:06.19

--- a/build-logs/2026-02-25T061037-issue27-postgres-batch-test.txt
+++ b/build-logs/2026-02-25T061037-issue27-postgres-batch-test.txt
@@ -1,0 +1,65 @@
+  復元対象のプロジェクトを決定しています...
+  復元対象のすべてのプロジェクトは最新です。
+  AudioProcessor -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor\bin\Debug\net10.0\AudioProcessor.dll
+  Cli.Shared -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared\bin\Debug\net10.0\Cli.Shared.dll
+  AudioProcessor.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioProcessor.Tests\bin\Debug\net10.0\AudioProcessor.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+  STFTAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core\bin\Debug\net10.0\STFTAnalyzer.Core.dll
+  PeakAnalyzer.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core\bin\Debug\net10.0\PeakAnalyzer.Core.dll
+  AudioSplitter.Core -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core\bin\Debug\net10.0\AudioSplitter.Core.dll
+VSTest のバージョン 18.0.1 (x64)
+
+  Cli.Shared.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\Cli.Shared.Tests\bin\Debug\net10.0\Cli.Shared.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:    12、スキップ:     0、合計:    12、期間: 149 ms - AudioProcessor.Tests.dll (net10.0)
+  AudioSplitter.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli\bin\Debug\net10.0\AudioSplitter.Cli.dll
+  SoundAnalyzer.Cli -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli\bin\Debug\net10.0\SoundAnalyzer.Cli.dll
+  AudioSplitter.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll
+  STFTAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll
+  PeakAnalyzer.Core.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Core.Tests\bin\Debug\net10.0\AudioSplitter.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+C:\Users\KABAYAKI\source\repos\SoundProcessor\STFTAnalyzer.Core.Tests\bin\Debug\net10.0\STFTAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+C:\Users\KABAYAKI\source\repos\SoundProcessor\PeakAnalyzer.Core.Tests\bin\Debug\net10.0\PeakAnalyzer.Core.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+VSTest のバージョン 18.0.1 (x64)
+
+
+VSTest のバージョン 18.0.1 (x64)
+
+テスト実行を開始しています。お待ちください...
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+成功!   -失敗:     0、合格:    29、スキップ:     0、合計:    29、期間: 866 ms - Cli.Shared.Tests.dll (net10.0)
+  SoundAnalyzer.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll
+  AudioSplitter.Cli.Tests -> C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll
+C:\Users\KABAYAKI\source\repos\SoundProcessor\AudioSplitter.Cli.Tests\bin\Debug\net10.0\AudioSplitter.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+C:\Users\KABAYAKI\source\repos\SoundProcessor\SoundAnalyzer.Cli.Tests\bin\Debug\net10.0\SoundAnalyzer.Cli.Tests.dll (.NETCoreApp,Version=v10.0) のテスト実行
+VSTest のバージョン 18.0.1 (x64)
+VSTest のバージョン 18.0.1 (x64)
+
+
+テスト実行を開始しています。お待ちください...
+テスト実行を開始しています。お待ちください...
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+合計 1 個のテスト ファイルが指定されたパターンと一致しました。
+
+
+成功!   -失敗:     0、合格:     7、スキップ:     0、合計:     7、期間: 734 ms - STFTAnalyzer.Core.Tests.dll (net10.0)
+成功!   -失敗:     0、合格:     8、スキップ:     0、合計:     8、期間: 762 ms - AudioSplitter.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:     5、スキップ:     0、合計:     5、期間: 774 ms - PeakAnalyzer.Core.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    15、スキップ:     0、合計:    15、期間: 968 ms - AudioSplitter.Cli.Tests.dll (net10.0)
+
+成功!   -失敗:     0、合格:    92、スキップ:     0、合計:    92、期間: 6 s - SoundAnalyzer.Cli.Tests.dll (net10.0)

--- a/build-logs/2026-02-25T061107-issue27-postgres-batch-help-audiosplitter.txt
+++ b/build-logs/2026-02-25T061107-issue27-postgres-batch-help-audiosplitter.txt
@@ -1,0 +1,19 @@
+Usage:
+  AudioSplitter.Cli.exe (--input-file <path> | --input-dir <path>) --output-dir <path> --level <dBFS> --duration <time> [options]
+
+Required options:
+  --input-file <path>       Input audio file path (wav/flac/m4a/caf)
+  --input-dir <path>        Input directory path
+  --output-dir <path>       Output directory path
+  --level <dBFS>            Silence threshold in dBFS, negative value only
+  --duration <time>         Silence duration threshold (e.g. 2000ms, 2s, 1m)
+
+Optional:
+  --recursive               Scan input directory recursively (available with --input-dir)
+  --after-offset <time>     Keep this duration from silence start in previous segment (default: 0ms)
+  --resume-offset <time>    Offset from next sound start for next segment, negative allowed (default: 0ms)
+  --resolution-type <spec>  Output resolution: 16bit|24bit|32float,<rate>hz
+  --ffmpeg-path <path>      ffmpeg executable path or directory containing ffmpeg/ffprobe
+  --progress                Show two-line progress bars on interactive stderr
+  -y                        Overwrite output without confirmation
+  --help, -h                Show help

--- a/build-logs/2026-02-25T061129-issue27-postgres-batch-help-soundanalyzer.txt
+++ b/build-logs/2026-02-25T061129-issue27-postgres-batch-help-soundanalyzer.txt
@@ -1,0 +1,64 @@
+Usage:
+  SoundAnalyzer.Cli.exe --window-size <len> --hop <len> --input-dir <path> --mode <peak-analysis|stft-analysis> [--db-file <path> | --postgres ...] [options]
+
+Required options:
+  --window-size <len>       Analysis window size (ms/s/m/sample/samples)
+  --hop <len>               Hop size (ms/s/m/sample/samples)
+  --input-dir <path>        Input root directory
+  --mode <value>            peak-analysis or stft-analysis
+
+Storage backend:
+  (default: SQLite)
+  --db-file <path>          SQLite db file path
+  --postgres                Enable PostgreSQL storage backend
+
+PostgreSQL connection options (required with --postgres):
+  --postgres-host <host>    PostgreSQL host
+  --postgres-port <port>    PostgreSQL port
+  --postgres-db <name>      PostgreSQL database name
+  --postgres-user <user>    PostgreSQL user
+  --postgres-password <pw>  PostgreSQL password (exclusive with ssl cert/key auth)
+  --postgres-sslcert-path <path>
+                            PostgreSQL client certificate path (requires sslkey-path)
+  --postgres-sslkey-path <path>
+                            PostgreSQL client private key path (requires sslcert-path)
+  --postgres-sslrootcert-path <path>
+                            PostgreSQL root CA certificate path (optional)
+  --postgres-ssh-host <host>
+                            Enable SSH tunnel to PostgreSQL automatically
+  --postgres-ssh-port <port>
+                            SSH port (default: 22)
+  --postgres-ssh-user <user>
+                            SSH user (required with postgres-ssh-host)
+  --postgres-ssh-private-key-path <path>
+                            SSH private key file path (required with postgres-ssh-host)
+  --postgres-ssh-known-hosts-path <path>
+                            SSH known_hosts file path (required with postgres-ssh-host)
+  --postgres-batch-row-count <n>
+                            PostgreSQL mode only. Multi-row INSERT batch size (default: 1)
+
+Optional:
+  --target-sampling <n>hz   Required when window/hop uses sample(s) in stft mode
+  --stems <csv>             Peak mode only. Stem names to analyze (case-insensitive)
+  --table-name-override <n> Override table name (default: peak=T_PeakAnalysis, stft=T_STFTAnalysis)
+  --upsert                  Upsert by unique key
+  --skip-duplicate          Skip duplicates by unique key
+  --min-limit-db <dB>       Clamp lower dB bound for all windows/bins (default: -120.0)
+  --bin-count <n>           STFT mode only. Number of output bands (required in stft-analysis)
+  --delete-current          STFT mode only. Drop current table before processing
+  --recursive               STFT mode only. Scan files recursively from input-dir
+  --stft-proc-threads <n>   STFT mode only. Processing threads per file (default: 1)
+  --peak-proc-threads <n>   Peak mode only. Processing threads per song (default: 1)
+  --stft-file-threads <n>   STFT mode only. Number of files analyzed in parallel (default: 1)
+  --peak-file-threads <n>   Peak mode only. Number of songs analyzed in parallel (default: 1)
+  --insert-queue-size <n>   Bounded queue size between analyze and DB insert (default: 1024)
+  --sqlite-fast-mode        SQLite mode only. Enable write-speed PRAGMA tuning (durability trade-off)
+  --sqlite-batch-row-count <n>
+                            SQLite mode only. Multi-row INSERT batch size (default: 512)
+  --ffmpeg-path <path>      ffmpeg executable path or directory containing ffmpeg/ffprobe
+  --show-progress           Show advanced progress UI on interactive stderr
+  --help, -h                Show help
+
+Examples:
+  SoundAnalyzer.Cli.exe --window-size 50ms --hop 10ms --input-dir /path/to/dir --db-file /path/to/file.db --mode peak-analysis --stems Piano,Drums --peak-file-threads 2 --peak-proc-threads 4 --insert-queue-size 2048 --show-progress
+  SoundAnalyzer.Cli.exe --window-size 2048samples --hop 512samples --target-sampling 44100hz --input-dir /path/to/dir --mode stft-analysis --bin-count 12 --postgres --postgres-host localhost --postgres-port 5432 --postgres-db audio --postgres-user analyzer --postgres-password secret --stft-file-threads 2 --stft-proc-threads 6 --insert-queue-size 4096 --show-progress


### PR DESCRIPTION
## Summary
- add PostgreSQL-only CLI option `--postgres-batch-row-count` (default `1`) to `SoundAnalyzer.Cli`
- apply configurable batch row count to both PostgreSQL stores (`PostgresPeakAnalysisStore` / `PostgresStftAnalysisStore`)
- introduce shared PostgreSQL batch clamp utility based on parameter limit (`65535`)
- add parser/store unit tests for default/valid/invalid values and clamp behavior
- update help text and README docs for the new option and behavior

## Validation
- `dotnet build AudioProcessor.slnx -warnaserror`
- `dotnet test AudioProcessor.slnx`
- `dotnet run --project AudioSplitter.Cli -- --help`
- `dotnet run --project SoundAnalyzer.Cli -- --help`
- logs:
  - `build-logs/2026-02-25T061022-issue27-postgres-batch-build.txt`
  - `build-logs/2026-02-25T061037-issue27-postgres-batch-test.txt`
  - `build-logs/2026-02-25T061107-issue27-postgres-batch-help-audiosplitter.txt`
  - `build-logs/2026-02-25T061129-issue27-postgres-batch-help-soundanalyzer.txt`

Fixes #27
